### PR TITLE
Radio error fix

### DIFF
--- a/boards/hamilton/include/board.h
+++ b/boards/hamilton/include/board.h
@@ -46,9 +46,6 @@ extern "C" {
 #define XTIMER_DEV                     TIMER_RTT
 #define XTIMER_CHAN                    (0)
 #define XTIMER_HZ                      32768UL
-//#define XTIMER_SHIFT                   (0)
-//#define XTIMER_USEC_TO_TICKS(value)    ( div_u32_by_15625div512(value) )
-//#define XTIMER_TICKS_TO_USEC(value)    ( ((uint64_t)value * 15625)>>9 )
 
 /**
  * @name AT86RF233 configuration

--- a/boards/hamilton/include/board.h
+++ b/boards/hamilton/include/board.h
@@ -46,8 +46,9 @@ extern "C" {
 #define XTIMER_DEV                     TIMER_RTT
 #define XTIMER_CHAN                    (0)
 #define XTIMER_HZ                      32768UL
-#define XTIMER_USEC_TO_TICKS(value)    ( div_u32_by_15625div512(value) )
-#define XTIMER_TICKS_TO_USEC(value)    ( ((uint64_t)value * 15625)>>9 )
+//#define XTIMER_SHIFT                   (0)
+//#define XTIMER_USEC_TO_TICKS(value)    ( div_u32_by_15625div512(value) )
+//#define XTIMER_TICKS_TO_USEC(value)    ( ((uint64_t)value * 15625)>>9 )
 
 /**
  * @name AT86RF233 configuration

--- a/cpu/sam21_common/periph/i2c.c
+++ b/cpu/sam21_common/periph/i2c.c
@@ -89,7 +89,7 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
             mux = I2C_0_MUX;
             clock_source_speed = CLOCK_CORECLOCK;
             sercom_gclk_id = I2C_0_GCLK_ID;
-            sercom_gclk_id_slow = I2C_0_GCLK_ID_SLOW ;
+            sercom_gclk_id_slow = I2C_0_GCLK_ID_SLOW;
             break;
 #endif
         default:
@@ -172,6 +172,7 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
             DEBUG("BAD BAUDRATE\n");
             return -2;
     }
+	//printf("i2c baud: %lu\n", tmp_baud);
 
     /* ENABLE I2C MASTER */
     i2c_poweron(dev);

--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -105,7 +105,7 @@ static void clk_init(void)
 #if TIMER_RTT_EN
     // hskim: Setup Clock generator 2 with divider 1 (32.768kHz)
     GCLK->GENDIV.reg  = (GCLK_GENDIV_ID(2)  | GCLK_GENDIV_DIV(0));
-    GCLK->GENCTRL.reg = (GCLK_GENCTRL_ID(2) | GCLK_GENCTRL_GENEN | GCLK_GENCTRL_DIVSEL |
+    GCLK->GENCTRL.reg = (GCLK_GENCTRL_ID(2) | GCLK_GENCTRL_GENEN | //GCLK_GENCTRL_DIVSEL |
 #if RTT_RUNSTDBY
                          GCLK_GENCTRL_RUNSTDBY |
 #endif

--- a/cpu/samd21/periph/spi.c
+++ b/cpu/samd21/periph/spi.c
@@ -85,14 +85,14 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
         break;
     case SPI_SPEED_5MHZ:
 #if CLOCK_CORECLOCK >= 5000000
-        f_baud = 5000000UL;
+        f_baud = 5000000;
         break;
 #else
         return -1;
 #endif
     case SPI_SPEED_10MHZ:
 #if CLOCK_CORECLOCK >= 10000000
-        f_baud = 10000000UL;
+        f_baud = 10000000;
         break;
 #else
         return -1;

--- a/cpu/samd21/periph/spi.c
+++ b/cpu/samd21/periph/spi.c
@@ -85,14 +85,14 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
         break;
     case SPI_SPEED_5MHZ:
 #if CLOCK_CORECLOCK >= 5000000
-        f_baud = 5000000;
+        f_baud = 5000000UL;
         break;
 #else
         return -1;
 #endif
     case SPI_SPEED_10MHZ:
 #if CLOCK_CORECLOCK >= 10000000
-        f_baud = 10000000;
+        f_baud = 10000000UL;
         break;
 #else
         return -1;
@@ -178,6 +178,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
 
     /* Setup clock */
     /* SPI using CLK GEN 0 */
+	/* hskim: We use Clock generator 3 for SPI, which has 6MHz */
     GCLK->CLKCTRL.reg = (GCLK_CLKCTRL_CLKEN |
                          GCLK_CLKCTRL_GEN_GCLK0 |
                          GCLK_CLKCTRL_ID(sercom_gclk_id));
@@ -189,6 +190,7 @@ int spi_init_master(spi_t dev, spi_conf_t conf, spi_speed_t speed)
     spi_dev->CTRLA.reg |= SERCOM_SPI_CTRLA_MODE_SPI_MASTER;
     while (spi_dev->SYNCBUSY.reg) {}// ???? not needed
 
+	//printf("spi baud: %u, baud_F: %lu\n", (uint8_t) (((uint32_t)CLOCK_CORECLOCK) / (2 * f_baud) - 1), f_baud);
     spi_dev->BAUD.bit.BAUD = (uint8_t) (((uint32_t)CLOCK_CORECLOCK) / (2 * f_baud) - 1); /* Synchronous mode*/
 
     spi_dev->CTRLA.reg |= SERCOM_SPI_CTRLA_DOPO(dopo)

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -187,6 +187,7 @@ void at86rf2xx_tx_prepare(at86rf2xx_t *dev)
     uint8_t state;
 
     dev->pending_tx++;
+	
     /* make sure ongoing transmissions are finished */
     do {
         state = at86rf2xx_get_status(dev);

--- a/drivers/at86rf2xx/at86rf2xx_internal.c
+++ b/drivers/at86rf2xx/at86rf2xx_internal.c
@@ -132,12 +132,13 @@ void at86rf2xx_assert_awake(at86rf2xx_t *dev)
 		/** hskim: OSCULP32K is an inaccurate oscilator.
 			   We cannot guarantee state trasition solely depending on timer. 
 	           Instead, we need to explicitly guarantee that the radio state is actually converted */
-		while ((at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATUS) & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS) !=
+		while ((at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATUS) & 
+		        AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS) !=
 			   AT86RF2XX_TRX_STATUS__TRX_OFF);
 
         /* update state */
-        dev->state = (at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATUS)
-                         & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS);
+        dev->state = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATUS)
+                         & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS;
     }
 }
 
@@ -155,10 +156,12 @@ void at86rf2xx_hardware_reset(at86rf2xx_t *dev)
 	/** hskim: OSCULP32K is an inaccurate oscilator.
 		   We cannot guarantee state trasition solely depending on timer. 
            Instead, we need to explicitly guarantee that the radio state is actually converted */	
-	while ((at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATUS) & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS) !=
-			   AT86RF2XX_TRX_STATUS__TRX_OFF &&
-           (at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATUS) & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS) !=
-			   AT86RF2XX_TRX_STATUS__P_ON);
+	while ((at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATUS) & 
+			AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS) !=
+		   AT86RF2XX_TRX_STATUS__TRX_OFF &&
+           (at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATUS) & 
+		    AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS) !=
+		   AT86RF2XX_TRX_STATUS__P_ON);
 	//printf("after reset %x\n", (at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATUS) & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS));
 }
 

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -78,6 +78,10 @@ static int _init(netdev2_t *netdev)
     gpio_set(dev->params.reset_pin);
     gpio_init_int(dev->params.int_pin, GPIO_IN, GPIO_RISING, _irq_handler, dev);
 
+	/* hskim: initialize dev state according to GPIO settings */ 
+	dev->state = (at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_STATUS)
+                         & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS); 
+
     /* make sure device is not sleeping, so we can query part number */
     at86rf2xx_assert_awake(dev);
 

--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2.c
@@ -141,10 +141,12 @@ static void *_gnrc_netdev2_thread(void *args)
         /* dispatch NETDEV and NETAPI messages */
         switch (msg.type) {
             case NETDEV2_MSG_TYPE_EVENT:
+				//printf("event is called\n");    			
                 DEBUG("gnrc_netdev2: GNRC_NETDEV_MSG_TYPE_EVENT received\n");
                 dev->driver->isr(dev);
                 break;
             case GNRC_NETAPI_MSG_TYPE_SND:
+				//printf("send is called\n");
                 DEBUG("gnrc_netdev2: GNRC_NETAPI_MSG_TYPE_SND received\n");
                 gnrc_pktsnip_t *pkt = msg.content.ptr;
                 gnrc_netdev2->send(gnrc_netdev2, pkt);
@@ -152,6 +154,7 @@ static void *_gnrc_netdev2_thread(void *args)
             case GNRC_NETAPI_MSG_TYPE_SET:
                 /* read incoming options */
                 opt = msg.content.ptr;
+				//printf("set is called\n");
                 DEBUG("gnrc_netdev2: GNRC_NETAPI_MSG_TYPE_SET received. opt=%s\n",
                         netopt2str(opt->opt));
                 /* set option for device driver */
@@ -164,7 +167,8 @@ static void *_gnrc_netdev2_thread(void *args)
                 break;
             case GNRC_NETAPI_MSG_TYPE_GET:
                 /* read incoming options */
-                opt = msg.content.ptr;
+				//printf("get is called\n");
+    			opt = msg.content.ptr;
                 DEBUG("gnrc_netdev2: GNRC_NETAPI_MSG_TYPE_GET received. opt=%s\n",
                         netopt2str(opt->opt));
                 /* get option from device driver */

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -45,7 +45,7 @@ void _xtimer_tsleep(uint32_t offset, uint32_t long_offset)
         _xtimer_spin(offset);
         return;
     }
-
+	//printf("offset %lu\n",offset);
     xtimer_t timer;
     mutex_t mutex = MUTEX_INIT;
 


### PR DESCRIPTION
AT86RF233 requires some time interval for a state transition.
Current radio driver waits for  the interval by using xtimer_usleep.
However, since our oscillator is inaccurate, radio state transition does not finish after the timer expires, which causes errors. Thus, I add while() statement to explicitly guarantee that each radio transition finishes.
