### PR TITLE
C7.2 easyapp

### DIFF
--- a/boards/hamilton/include/periph_conf.h
+++ b/boards/hamilton/include/periph_conf.h
@@ -79,11 +79,7 @@ extern "C" {
 
 #define PM_BLOCKER_INITIAL { .val_u32=0x00000000 }
 
-
-#ifndef LEAF_NODE
-#define LEAF_NODE (1) /* Duty-cycling node */
-#endif
-#define AUTO_CSMA_EN               (0)
+#define AUTO_CSMA_EN        (0)
 /** @} */
 
 /**

--- a/boards/hamilton/include/periph_conf.h
+++ b/boards/hamilton/include/periph_conf.h
@@ -227,7 +227,7 @@ static const spi_conf_t spi_config[] = {
 #define HDC1000_PARAMS_BOARD    { .i2c  = I2C_0, \
                                   .addr = 0x40, \
                                   .res  = HDC1000_14BIT }
-#define HDC1000_CONVERSION_TIME 15000UL
+#define HDC1000_CONVERSION_TIME 150000UL
 
 #define FXOS8700_PARAMS_BOARD   { .i2c  = I2C_0, \
                                   .addr = 0x1e }
@@ -235,7 +235,7 @@ static const spi_conf_t spi_config[] = {
 #define TMP006_PARAMS_BOARD     { .i2c  = I2C_0, \
                                   .addr = 0x44, \
                                   .conv_rate  = TMP006_CONFIG_CR_AS2 }
-#define TMP006_CONVERSION_TIME  501000UL  
+#define TMP006_CONVERSION_TIME  550000UL  
 
 #define APDS9007_PARAMS_BOARD    { .gpio = GPIO_PIN(PA,28), \
 																	 .adc  = ADC_PIN_PA08, \

--- a/boards/hamilton/include/periph_conf.h
+++ b/boards/hamilton/include/periph_conf.h
@@ -82,6 +82,7 @@ extern "C" {
 #define AUTO_CSMA_EN        (0)
 /** @} */
 
+
 /**
  * @name Timer peripheral configuration
  * @{
@@ -209,6 +210,40 @@ static const spi_conf_t spi_config[] = {
 #define I2C_0_SDA           GPIO_PIN(PA, 16)
 #define I2C_0_SCL           GPIO_PIN(PA, 17)
 #define I2C_0_MUX           GPIO_MUX_D
+/** @} */
+
+/**
+ * @name LED configuration
+ * @{
+ */
+#define LED_NUMOF           (1U)
+#define LED0_PIN            GPIO_PIN(0,19)
+/** @} */
+
+/**
+ * @name Sensor configuration
+ * @{
+ */
+#define HDC1000_PARAMS_BOARD    { .i2c  = I2C_0, \
+                                  .addr = 0x40, \
+                                  .res  = HDC1000_14BIT }
+#define HDC1000_CONVERSION_TIME 15000UL
+
+#define FXOS8700_PARAMS_BOARD   { .i2c  = I2C_0, \
+                                  .addr = 0x1e }
+
+#define TMP006_PARAMS_BOARD     { .i2c  = I2C_0, \
+                                  .addr = 0x44, \
+                                  .conv_rate  = TMP006_CONFIG_CR_AS2 }
+#define TMP006_CONVERSION_TIME  501000UL  
+
+#define APDS9007_PARAMS_BOARD    { .gpio = GPIO_PIN(PA,28), \
+																	 .adc  = ADC_PIN_PA08, \
+																	 .res  = ADC_RES_16BIT }
+#define APDS9007_STABILIZATION_TIME 20000UL
+
+#define EKMB1101111_PARAMS_BOARD    { .gpio = GPIO_PIN(PA,6 ) }
+#define PUSH_BUTTON_PARAMS_BOARD    { .gpio = GPIO_PIN(PA,18) }
 /** @} */
 
 /**

--- a/boards/hamilton/include/periph_conf.h
+++ b/boards/hamilton/include/periph_conf.h
@@ -73,7 +73,7 @@ extern "C" {
 #elif CLOCK_USE_FLL
 #define CLOCK_CORECLOCK     48000000U
 #else
-#define CLOCK_CORECLOCK     32768U
+#define CLOCK_CORECLOCK      8000000U//32768U
 #endif
 /** @} */
 
@@ -138,8 +138,8 @@ static const uart_conf_t uart_config[] = {
  * @{
  */
 #define PWM_NUMOF           (PWM_0_EN + PWM_1_EN)
-#define PWM_0_EN            1
-#define PWM_1_EN            1
+#define PWM_0_EN            0
+#define PWM_1_EN            0
 #define PWM_MAX_CHANNELS    2
 /* for compatibility with test application */
 #define PWM_0_CHANNELS      PWM_MAX_CHANNELS

--- a/boards/hamilton/include/periph_conf.h
+++ b/boards/hamilton/include/periph_conf.h
@@ -87,10 +87,6 @@ extern "C" {
 #define DUTYCYCLE_EN               (1)
 #endif
 
-#ifndef DUTYCYCLE_WAKEUP_INTERVAL
-#define DUTYCYCLE_WAKEUP_INTERVAL  6000UL    /* Don't change it w/o particular reasons */
-#endif
-
 #ifndef DUTYCYCLE_SLEEP_INTERVAL
 #define DUTYCYCLE_SLEEP_INTERVAL   2000000UL /* 1) When it is ZERO, a leaf node does not send beacons
                         												(i.e., extremely low duty-cycle,
@@ -100,8 +96,9 @@ extern "C" {
                         												   but uses the value for downlink transmissions */
 #endif
 
-#define ROUTER    (0)        /* Plugged-in router */
-#define LEAF_NODE (1-ROUTER) /* Duty-cycling node */
+#ifndef LEAF_NODE
+#define LEAF_NODE (1) /* Duty-cycling node */
+#endif
 #define AUTO_CSMA_EN               (0)
 /** @} */
 

--- a/boards/hamilton/include/periph_conf.h
+++ b/boards/hamilton/include/periph_conf.h
@@ -79,22 +79,6 @@ extern "C" {
 
 #define PM_BLOCKER_INITIAL { .val_u32=0x00000000 }
 
-/**
- * @name Network configuration
- * @{
- */
-#ifndef DUTYCYCLE_EN
-#define DUTYCYCLE_EN               (1)
-#endif
-
-#ifndef DUTYCYCLE_SLEEP_INTERVAL
-#define DUTYCYCLE_SLEEP_INTERVAL   2000000UL /* 1) When it is ZERO, a leaf node does not send beacons
-                        												(i.e., extremely low duty-cycle,
-                                                        but downlink transmission is disabled)
-                                                2) Router and leaf node should have same sleep interval.
-                        												   Router does not sleep
-                        												   but uses the value for downlink transmissions */
-#endif
 
 #ifndef LEAF_NODE
 #define LEAF_NODE (1) /* Duty-cycling node */

--- a/cpu/samd21/periph/pwm.c
+++ b/cpu/samd21/periph/pwm.c
@@ -20,6 +20,7 @@
  * @}
  */
 
+#if PWM_NUMOF
 #include <stdint.h>
 #include <string.h>
 
@@ -28,6 +29,7 @@
 #include "board.h"
 #include "periph/gpio.h"
 #include "periph/pwm.h"
+
 
 
 static inline int _num(pwm_t dev)
@@ -186,3 +188,4 @@ void pwm_poweroff(pwm_t dev)
                          GCLK_CLKCTRL_ID(_clk_id(dev)));
     while (GCLK->STATUS.bit.SYNCBUSY) {}
 }
+#endif

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -97,6 +97,21 @@ endif
 ifneq (,$(filter hdc1000,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/drivers/hdc1000/include
 endif
+ifneq (,$(filter fxos8700,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/drivers/fxos8700/include
+endif
+ifneq (,$(filter tmp006,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/drivers/tmp006/include
+endif
+ifneq (,$(filter apds9007,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/drivers/apds9007/include
+endif
+ifneq (,$(filter ekmb1101111,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/drivers/ekmb1101111/include
+endif
+ifneq (,$(filter push_button,$(USEMODULE)))
+    USEMODULE_INCLUDES += $(RIOTBASE)/drivers/push_button/include
+endif
 ifneq (,$(filter lis3dh,$(USEMODULE)))
     USEMODULE_INCLUDES += $(RIOTBASE)/drivers/lis3dh/include
 endif

--- a/drivers/apds9007/Makefile
+++ b/drivers/apds9007/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/apds9007/apds9007.c
+++ b/drivers/apds9007/apds9007.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2017 Hyung-Sin Kim
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     drivers_apds9007
+ * @{
+ *
+ * @file
+ * @brief       Driver for the APDS9007 Light Sensor.
+ *
+ * @author      Hyung-Sin Kim <hs.kim@berkeley.edu>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "apds9007.h"
+#include "xtimer.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+
+int apds9007_set_active(apds9007_t *dev)
+{
+	gpio_write(dev->p.gpio, 0);
+	return 0;
+} 
+
+int apds9007_set_idle(apds9007_t *dev)
+{
+	gpio_write(dev->p.gpio, 1);
+  return 0;
+}
+
+int apds9007_init(apds9007_t *dev, const apds9007_params_t *params)
+{    
+		dev->p.gpio = params->gpio;
+		dev->p.adc  = params->adc;
+		dev->p.res  = params->res;
+    gpio_init(params->gpio, GPIO_OUT);
+		adc_init(params->adc);
+		apds9007_set_idle(dev);
+    return 0;
+}
+
+int apds9007_read(apds9007_t *dev, int16_t *light)
+{
+	apds9007_set_active(dev);
+	xtimer_usleep(APDS9007_STABILIZATION_TIME);
+	*light = (int16_t) adc_sample(dev->p.adc, dev->p.res);
+	apds9007_set_idle(dev);
+  return 0;
+}
+

--- a/drivers/apds9007/apds9007_saul.c
+++ b/drivers/apds9007/apds9007_saul.c
@@ -26,7 +26,10 @@
 static int read(void *dev, phydat_t *res)
 {
     apds9007_t *d = (apds9007_t *)dev;
-    apds9007_read(d, &(res->val[0]));
+    if (apds9007_read(d, &(res->val[0]))) {
+			/* Read failure */
+			return 0;
+		}
     memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
     res->unit = UNIT_LUX;
     res->scale = 0;

--- a/drivers/apds9007/apds9007_saul.c
+++ b/drivers/apds9007/apds9007_saul.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2017 Hyung-Sin Kim
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     driver_apds9007
+ * @{
+ *
+ * @file
+ * @brief       APDS9007 adaption to the RIOT actuator/sensor interface
+ *
+ * @author      Hyung-Sin Kim <hs.kim@berkeley.edu>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "saul.h"
+#include "apds9007.h"
+
+static int read(void *dev, phydat_t *res)
+{
+    apds9007_t *d = (apds9007_t *)dev;
+    apds9007_read(d, &(res->val[0]));
+    memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
+    res->unit = UNIT_LUX;
+    res->scale = 0;
+    return 1;
+}
+
+const saul_driver_t apds9007_saul_light_driver = {
+    .read = read,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_LIGHT,
+};

--- a/drivers/apds9007/apds9007_saul.c
+++ b/drivers/apds9007/apds9007_saul.c
@@ -28,7 +28,7 @@ static int read(void *dev, phydat_t *res)
     apds9007_t *d = (apds9007_t *)dev;
     if (apds9007_read(d, &(res->val[0]))) {
 			/* Read failure */
-			return 0;
+			return -ECANCELED;
 		}
     memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
     res->unit = UNIT_LUX;

--- a/drivers/apds9007/include/apds9007_params.h
+++ b/drivers/apds9007/include/apds9007_params.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2017 Hyung-Sin Kim
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_apds9007
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for APDS9007 devices
+ *
+ * @author      Hyung-Sin Kim <hs.kim@berkeley.edu>
+ */
+
+#ifndef APDS9007_PARAMS_H
+#define APDS9007_PARAMS_H
+
+#include "board.h"
+#include "apds9007.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Set default configuration parameters for the APDS9007 driver
+ * @{
+ */
+#ifndef APDS9007_PARAMS_BOARD
+#define APDS9007_PARAMS_DEFAULT    { .gpio  = GPIO_PIN(PA,28), \
+																		 .adc   = ADC_PIN_PA08, \
+																		 .res   = ADC_RES_16BIT }
+#endif 
+/**@}*/
+
+/**
+ * @brief   APDS9007 configuration
+ */
+static const apds9007_params_t apds9007_params[] =
+{
+#ifdef APDS9007_PARAMS_BOARD
+    APDS9007_PARAMS_BOARD,
+#else
+    APDS9007_PARAMS_DEFAULT,
+#endif
+};
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t apds9007_saul_info[] =
+{
+    {
+        .name = "apds9007",
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* APDS9007_PARAMS_H */
+/** @} */

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -215,10 +215,14 @@ void at86rf2xx_tx_exec(at86rf2xx_t *dev)
 #if AUTO_CSMA_EN
 #else
     while(!at86rf2xx_cca(dev)) {
-      at86rf2xx_set_state(dev, AT86RF2XX_STATE_RX_AACK_ON); /* Listening during backoff */
+#if LEAF_NODE
+      at86rf2xx_set_state(dev, AT86RF2XX_STATE_FORCE_TRX_OFF); /* Listening during backoff */
+#else
+      at86rf2xx_set_state(dev, AT86RF2XX_STATE_RX_AACK_ON); /* Listening during backoff */	
+#endif
       xtimer_usleep((rand()%(2^BE))*320);
       at86rf2xx_set_state(dev, AT86RF2XX_STATE_TX_ARET_ON);
-      printf("CCA busy %u\n", (2^BE)*320);
+      DEBUG("CCA busy %u\n", (2^BE)*320);
       if (BE < MAX_BE) {
         BE++;
       }    

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -576,8 +576,9 @@ static void _isr(netdev2_t *netdev)
              * there are none */
             assert(dev->pending_tx != 0);
             if ((--dev->pending_tx) == 0) {
-#if DUTYCYCLE_EN
+#if MODULE_GNRC_DUTYMAC
 #if LEAF_NODE
+				/* Wake up for a while when receiving an ACK with pending bit */
 				if (trac_status == AT86RF2XX_TRX_STATE__TRAC_SUCCESS_DATA_PENDING) {
 	                dev->idle_state = AT86RF2XX_STATE_RX_AACK_ON;		
 				}

--- a/drivers/ekmb1101111/Makefile
+++ b/drivers/ekmb1101111/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/ekmb1101111/ekmb1101111.c
+++ b/drivers/ekmb1101111/ekmb1101111.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2017 Hyung-Sin Kim
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     drivers_ekmb1101111
+ * @{
+ *
+ * @file
+ * @brief       Driver for the EKMB1101111 PIR Motion Sensor.
+ *
+ * @author      Hyung-Sin Kim <hs.kim@berkeley.edu>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "ekmb1101111.h"
+#include "xtimer.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+bool     pin_high;
+uint64_t pin_rise_time;
+uint64_t accum_up_time;
+uint64_t last_reset_time;
+
+void ekmb1101111_trigger(void* arg) {
+	ekmb1101111_t* dev = (ekmb1101111_t*) arg;
+  int pin_now = gpio_read(dev->p.gpio);
+;
+  //We were busy counting
+  if (pin_high) {
+    //Add into accumulation
+		uint64_t now = xtimer_usec_from_ticks64(xtimer_now64());
+    accum_up_time += (now - pin_rise_time);
+  }
+  if (pin_now) { // Pin is rising
+    pin_rise_time = xtimer_usec_from_ticks64(xtimer_now64());
+    pin_high = true;
+  } else {       // Pin is falling
+    pin_high = false;
+  }
+}
+
+int ekmb1101111_init(ekmb1101111_t *dev, const ekmb1101111_params_t *params)
+{    
+		dev->p.gpio = params->gpio;
+		pin_high = false;
+		accum_up_time = 0;
+		pin_rise_time = 0;
+    last_reset_time = xtimer_usec_from_ticks64(xtimer_now64());
+    gpio_init_int(params->gpio, GPIO_IN_PD, GPIO_BOTH, ekmb1101111_trigger, dev);
+    return 0;
+}
+
+int ekmb1101111_read(ekmb1101111_t *dev, int16_t *occup)
+{
+  uint64_t now = xtimer_usec_from_ticks64(xtimer_now64());
+  *occup = (uint16_t)((accum_up_time * 10000) / (now - last_reset_time));
+	last_reset_time = now;
+	accum_up_time = 0;
+  return 0;
+}
+

--- a/drivers/ekmb1101111/ekmb1101111.c
+++ b/drivers/ekmb1101111/ekmb1101111.c
@@ -57,7 +57,9 @@ int ekmb1101111_init(ekmb1101111_t *dev, const ekmb1101111_params_t *params)
 		accum_up_time = 0;
 		pin_rise_time = 0;
     last_reset_time = xtimer_usec_from_ticks64(xtimer_now64());
-    gpio_init_int(params->gpio, GPIO_IN_PD, GPIO_BOTH, ekmb1101111_trigger, dev);
+    if (gpio_init_int(params->gpio, GPIO_IN_PD, GPIO_BOTH, ekmb1101111_trigger, dev)) {
+			return -1;
+		}
     return 0;
 }
 

--- a/drivers/ekmb1101111/ekmb1101111_saul.c
+++ b/drivers/ekmb1101111/ekmb1101111_saul.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2017 Hyung-Sin Kim
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     driver_ekmb1101111
+ * @{
+ *
+ * @file
+ * @brief       EKMB1101111 adaption to the RIOT actuator/sensor interface
+ *
+ * @author      Hyung-Sin Kim <hs.kim@berkeley.edu>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "saul.h"
+#include "ekmb1101111.h"
+
+static int read_occup(void *dev, phydat_t *res)
+{
+    ekmb1101111_t *d = (ekmb1101111_t *)dev;
+    ekmb1101111_read(d, &(res->val[0]));
+    memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
+    res->unit = UNIT_PERCENT;
+    res->scale = -2;
+    return 1;
+}
+
+const saul_driver_t ekmb1101111_saul_occup_driver = {
+    .read = read_occup,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_OCCUP,
+};

--- a/drivers/ekmb1101111/ekmb1101111_saul.c
+++ b/drivers/ekmb1101111/ekmb1101111_saul.c
@@ -26,7 +26,10 @@
 static int read_occup(void *dev, phydat_t *res)
 {
     ekmb1101111_t *d = (ekmb1101111_t *)dev;
-    ekmb1101111_read(d, &(res->val[0]));
+    if (ekmb1101111_read(d, &(res->val[0]))) {
+			/* Read failure */
+			return 0;
+		}
     memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
     res->unit = UNIT_PERCENT;
     res->scale = -2;

--- a/drivers/ekmb1101111/ekmb1101111_saul.c
+++ b/drivers/ekmb1101111/ekmb1101111_saul.c
@@ -28,7 +28,7 @@ static int read_occup(void *dev, phydat_t *res)
     ekmb1101111_t *d = (ekmb1101111_t *)dev;
     if (ekmb1101111_read(d, &(res->val[0]))) {
 			/* Read failure */
-			return 0;
+			return -ECANCELED;
 		}
     memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
     res->unit = UNIT_PERCENT;

--- a/drivers/ekmb1101111/include/ekmb1101111_params.h
+++ b/drivers/ekmb1101111/include/ekmb1101111_params.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2017 Hyung-Sin Kim
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_ekmb1101111
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for EKMB1101111 devices
+ *
+ * @author      Hyung-Sin Kim <hs.kim@berkeley.edu>
+ */
+
+#ifndef EKMB1101111_PARAMS_H
+#define EKMB1101111_PARAMS_H
+
+#include "board.h"
+#include "ekmb1101111.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Set default configuration parameters for the APDS9007 driver
+ * @{
+ */
+#ifndef EKMB1101111_PARAMS_BOARD
+#define EKMB1101111_PARAMS_DEFAULT  { .gpio = GPIO_PIN(PA, 6) }
+#endif 
+/**@}*/
+
+/**
+ * @brief   EKMB1101111 configuration
+ */
+static const ekmb1101111_params_t ekmb1101111_params[] =
+{
+#ifdef EKMB1101111_PARAMS_BOARD
+    EKMB1101111_PARAMS_BOARD,
+#else
+    EKMB1101111_PARAMS_DEFAULT,
+#endif
+};
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t ekmb1101111_saul_info[] =
+{
+    {
+        .name = "ekmb110",
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EKMB1101111_PARAMS_H */
+/** @} */

--- a/drivers/fxos8700/fxos8700.c
+++ b/drivers/fxos8700/fxos8700.c
@@ -175,6 +175,10 @@ int fxos8700_read_mag(fxos8700_t* dev, fxos8700_measurement_mag_t* m)
 	uint8_t data[12];
 	uint8_t ready = 0;
 
+  if (fxos8700_set_active(dev)) {
+		return -1;
+	}
+
   while(!(ready & 0x08)) {
 		fxos8700_read_regs(dev, FXOS8700_REG__STATUS, &ready, 1);
 	}
@@ -184,7 +188,11 @@ int fxos8700_read_mag(fxos8700_t* dev, fxos8700_measurement_mag_t* m)
 
 	/* Read all data at once */
 	if (fxos8700_read_regs(dev, FXOS8700_REG_OUT_X_MSB, &data[0], 12)) {
-	  return -1;
+	  return -2;
+	}
+
+  if (fxos8700_set_idle(dev)) {
+		return -3;
 	}
 
 	/* Read magnetometer */
@@ -200,7 +208,11 @@ int fxos8700_read_acc(fxos8700_t* dev, fxos8700_measurement_acc_t* m)
 	uint8_t data[12];
 	uint8_t ready = 0;
 
-    while(!(ready & 0x08)) {
+  if (fxos8700_set_active(dev)) {
+		return -1;
+	}
+
+  while(!(ready & 0x08)) {
 		fxos8700_read_regs(dev, FXOS8700_REG__STATUS, &ready, 1);
 	}
 	while(!(ready & 0x08)) {
@@ -209,7 +221,11 @@ int fxos8700_read_acc(fxos8700_t* dev, fxos8700_measurement_acc_t* m)
 
 	/* Read all data at once */
 	if (fxos8700_read_regs(dev, FXOS8700_REG_OUT_X_MSB, &data[0], 12)) {
-	  return -1;
+	  return -2;
+	}
+
+  if (fxos8700_set_idle(dev)) {
+		return -3;
 	}
 
 	/* Read accelerometer */

--- a/drivers/fxos8700/fxos8700.c
+++ b/drivers/fxos8700/fxos8700.c
@@ -67,7 +67,7 @@ static int fxos8700_reset(fxos8700_t* dev)
 
 
 
-int fxos8700_init(fxos8700_t* dev, const fxos8700_params_t *params) //i2c_t i2c, uint8_t addr)
+int fxos8700_init(fxos8700_t* dev, const fxos8700_params_t *params) 
 {
     dev->p.i2c = params->i2c;
     int rv;
@@ -122,7 +122,6 @@ int fxos8700_init(fxos8700_t* dev, const fxos8700_params_t *params) //i2c_t i2c,
 }
 
 
-
 int fxos8700_set_active(fxos8700_t* dev)
 {
     uint8_t config = 0x01;
@@ -131,6 +130,7 @@ int fxos8700_set_active(fxos8700_t* dev)
     }
     return 0;
 }
+
 int fxos8700_set_idle(fxos8700_t* dev)
 {
     uint8_t config = 0x00;

--- a/drivers/fxos8700/fxos8700.c
+++ b/drivers/fxos8700/fxos8700.c
@@ -33,26 +33,26 @@
 
 static int fxos8700_read_regs(fxos8700_t* dev, uint8_t reg, uint8_t* data, size_t len)
 {
-    i2c_acquire(dev->i2c);
-    if(i2c_read_regs(dev->i2c, dev->addr, reg, (char*) data, len) <= 0) {
+    i2c_acquire(dev->p.i2c);
+    if(i2c_read_regs(dev->p.i2c, dev->p.addr, reg, (char*) data, len) <= 0) {
         DEBUG("[fxos8700] Can't read register 0x%x\n", reg);
-        i2c_release(dev->i2c);
+        i2c_release(dev->p.i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_release(dev->p.i2c);
 
     return 0;
 }
 
 static int fxos8700_write_regs(fxos8700_t* dev, uint8_t reg, uint8_t* data, size_t len)
 {
-    i2c_acquire(dev->i2c);
-    if(i2c_write_regs(dev->i2c, dev->addr, reg, (char*) data, len) <= 0) {
+    i2c_acquire(dev->p.i2c);
+    if(i2c_write_regs(dev->p.i2c, dev->p.addr, reg, (char*) data, len) <= 0) {
         DEBUG("[fxos8700] Can't write to register 0x%x\n", reg);
-        i2c_release(dev->i2c);
+        i2c_release(dev->p.i2c);
         return -1;
     }
-    i2c_release(dev->i2c);
+    i2c_release(dev->p.i2c);
 
     return 0;
 }
@@ -67,34 +67,34 @@ static int fxos8700_reset(fxos8700_t* dev)
 
 
 
-int fxos8700_init(fxos8700_t* dev, i2c_t i2c, uint8_t addr)
+int fxos8700_init(fxos8700_t* dev, const fxos8700_params_t *params) //i2c_t i2c, uint8_t addr)
 {
-    dev->i2c = i2c;
+    dev->p.i2c = params->i2c;
     int rv;
     uint8_t config;
 
-    if ( (addr < 0x1C) || (addr > 0x1F) ) {
+    if ( (params->addr < 0x1C) || (params->addr > 0x1F) ) {
         DEBUG("[fxos8700] Invalid address\n");
         return -2;
     }
-    dev->addr = addr;
+    dev->p.addr = params->addr;
 
-    i2c_acquire(dev->i2c);
-    if(i2c_init_master(dev->i2c, I2C_SPEED_NORMAL) != 0) {
+    i2c_acquire(dev->p.i2c);
+    if(i2c_init_master(dev->p.i2c, I2C_SPEED_NORMAL) != 0) {
         DEBUG("[fxos8700] Can't initialize I2C master\n");
-        i2c_release(dev->i2c);
+        i2c_release(dev->p.i2c);
         return -3;
     }
 
-    rv = i2c_read_regs(dev->i2c, dev->addr, 0x0D, &config, 1);
+    rv = i2c_read_regs(dev->p.i2c, dev->p.addr, 0x0D, &config, 1);
     if (rv != 1) {
-        i2c_release(dev->i2c);
+        i2c_release(dev->p.i2c);
 		    DEBUG("[fxos8700] Could not read WHOAMI (%d)\n", rv);
         return -4;
     }
 
     dev->whoami = config;
-    i2c_release(dev->i2c);
+    i2c_release(dev->p.i2c);
 
      /* Reset the device */
     if(fxos8700_reset(dev) != 0) {
@@ -166,6 +166,56 @@ int fxos8700_read(fxos8700_t* dev, fxos8700_measurement_t* m)
 	m->mag_x = (int16_t) ((data[6] <<8) | data[7]);
 	m->mag_y = (int16_t) ((data[8] <<8) | data[9]);
 	m->mag_z = (int16_t) ((data[10]<<8) | data[11]);
+
+	return 0;
+}
+
+int fxos8700_read_mag(fxos8700_t* dev, fxos8700_measurement_mag_t* m)
+{
+	uint8_t data[12];
+	uint8_t ready = 0;
+
+  while(!(ready & 0x08)) {
+		fxos8700_read_regs(dev, FXOS8700_REG__STATUS, &ready, 1);
+	}
+	while(!(ready & 0x08)) {
+		fxos8700_read_regs(dev, FXOS8700_REG_M_DR_STATUS, &ready, 1);
+	}
+
+	/* Read all data at once */
+	if (fxos8700_read_regs(dev, FXOS8700_REG_OUT_X_MSB, &data[0], 12)) {
+	  return -1;
+	}
+
+	/* Read magnetometer */
+	m->mag_x = (int16_t) ((data[6] <<8) | data[7]);
+	m->mag_y = (int16_t) ((data[8] <<8) | data[9]);
+	m->mag_z = (int16_t) ((data[10]<<8) | data[11]);
+
+	return 0;
+}
+
+int fxos8700_read_acc(fxos8700_t* dev, fxos8700_measurement_acc_t* m)
+{
+	uint8_t data[12];
+	uint8_t ready = 0;
+
+    while(!(ready & 0x08)) {
+		fxos8700_read_regs(dev, FXOS8700_REG__STATUS, &ready, 1);
+	}
+	while(!(ready & 0x08)) {
+		fxos8700_read_regs(dev, FXOS8700_REG_M_DR_STATUS, &ready, 1);
+	}
+
+	/* Read all data at once */
+	if (fxos8700_read_regs(dev, FXOS8700_REG_OUT_X_MSB, &data[0], 12)) {
+	  return -1;
+	}
+
+	/* Read accelerometer */
+	m->acc_x = (int16_t) ((data[0]<<6) | (data[1]>>2));
+	m->acc_y = (int16_t) ((data[2]<<6) | (data[3]>>2));
+	m->acc_z = (int16_t) ((data[4]<<6) | (data[5]>>2));
 
 	return 0;
 }

--- a/drivers/fxos8700/fxos8700_saul.c
+++ b/drivers/fxos8700/fxos8700_saul.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2017 Hyung-Sin Kim
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     driver_fxos8700
+ * @{
+ *
+ * @file
+ * @brief       FXOS8700 adaption to the RIOT actuator/sensor interface
+ *
+ * @author      Hyung-Sin Kim <hs.kim@berkeley.edu>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "saul.h"
+#include "fxos8700.h"
+
+static int read_mag(void *dev, phydat_t *res)
+{
+    fxos8700_t *d = (fxos8700_t *)dev;
+		fxos8700_set_active(d);
+    fxos8700_read_mag(d, (fxos8700_measurement_mag_t *)res);
+    fxos8700_set_idle(d);
+
+    res->unit = UNIT_GS;
+    res->scale = -3;
+    return 3;
+}
+
+static int read_acc(void *dev, phydat_t *res)
+{
+    fxos8700_t *d = (fxos8700_t *)dev;
+    fxos8700_set_active(d);
+    fxos8700_read_acc(d, (fxos8700_measurement_acc_t *)res);
+		fxos8700_set_idle(d);
+
+    res->unit = UNIT_G;
+    res->scale = -3;
+    return 3;
+}
+
+const saul_driver_t fxos8700_saul_mag_driver = {
+    .read = read_mag,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_MAG,
+};
+
+const saul_driver_t fxos8700_saul_acc_driver = {
+    .read = read_acc,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_ACCEL,
+};

--- a/drivers/fxos8700/fxos8700_saul.c
+++ b/drivers/fxos8700/fxos8700_saul.c
@@ -26,9 +26,10 @@
 static int read_mag(void *dev, phydat_t *res)
 {
     fxos8700_t *d = (fxos8700_t *)dev;
-		fxos8700_set_active(d);
-    fxos8700_read_mag(d, (fxos8700_measurement_mag_t *)res);
-    fxos8700_set_idle(d);
+    if (fxos8700_read_mag(d, (fxos8700_measurement_mag_t *)res)) {
+			/* Read failure */			
+			return 0;
+		}
 
     res->unit = UNIT_GS;
     res->scale = -3;
@@ -38,9 +39,10 @@ static int read_mag(void *dev, phydat_t *res)
 static int read_acc(void *dev, phydat_t *res)
 {
     fxos8700_t *d = (fxos8700_t *)dev;
-    fxos8700_set_active(d);
-    fxos8700_read_acc(d, (fxos8700_measurement_acc_t *)res);
-		fxos8700_set_idle(d);
+    if (fxos8700_read_acc(d, (fxos8700_measurement_acc_t *)res)) {
+			/* Read failure */			
+			return 0;
+		}
 
     res->unit = UNIT_G;
     res->scale = -3;

--- a/drivers/fxos8700/fxos8700_saul.c
+++ b/drivers/fxos8700/fxos8700_saul.c
@@ -28,7 +28,7 @@ static int read_mag(void *dev, phydat_t *res)
     fxos8700_t *d = (fxos8700_t *)dev;
     if (fxos8700_read_mag(d, (fxos8700_measurement_mag_t *)res)) {
 			/* Read failure */			
-			return 0;
+			return -ECANCELED;
 		}
 
     res->unit = UNIT_GS;

--- a/drivers/fxos8700/include/fxos8700_params.h
+++ b/drivers/fxos8700/include/fxos8700_params.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2017 Hyung-Sin Kim
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_fxos8700
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for FXOS8700 devices
+ *
+ * @author      Hyung-Sin Kim <hs.kim@berkeley.edu>
+ */
+
+#ifndef FXOS8700_PARAMS_H
+#define FXOS8700_PARAMS_H
+
+#include "board.h"
+#include "fxos8700.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Default configuration parameters for the FXOS8700 driver
+ * @{
+ */
+#define FXOS8700_PARAMS_DEFAULT   { .i2c  = I2C_0, \
+                                    .addr = 0x1e }
+
+/**@}*/
+
+/**
+ * @brief   FXOS8700 configuration
+ */
+static const fxos8700_params_t fxos8700_params[] =
+{
+#ifdef FXOS8700_PARAMS_BOARD
+    FXOS8700_PARAMS_BOARD,
+#else
+    FXOS8700_PARAMS_DEFAULT,
+#endif
+};
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t fxos8700_saul_info[] =
+{
+    {
+        .name = "fxos8700",
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FXOS8700_PARAMS_H */
+/** @} */

--- a/drivers/hdc1000/hdc1000_saul.c
+++ b/drivers/hdc1000/hdc1000_saul.c
@@ -27,7 +27,10 @@ static int read_temp(void *dev, phydat_t *res)
 {
     hdc1000_t *d = (hdc1000_t *)dev;
 
-    hdc1000_read(d, &(res->val[0]), NULL);
+    if (hdc1000_read(d, &(res->val[0]), NULL)) {
+			/* Read failure */			
+			return 0;
+		}
     memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
     res->unit = UNIT_TEMP_C;
     res->scale = -2;
@@ -39,7 +42,10 @@ static int read_hum(void *dev, phydat_t *res)
 {
     hdc1000_t *d = (hdc1000_t *)dev;
 
-    hdc1000_read(d, NULL, &(res->val[0]));
+    if (hdc1000_read(d, NULL, &(res->val[0]))) {			
+			/* Read failure */			
+			return 0;
+		}
     memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
     res->unit = UNIT_PERCENT;
     res->scale = -2;

--- a/drivers/hdc1000/hdc1000_saul.c
+++ b/drivers/hdc1000/hdc1000_saul.c
@@ -29,7 +29,7 @@ static int read_temp(void *dev, phydat_t *res)
 
     if (hdc1000_read(d, &(res->val[0]), NULL)) {
 			/* Read failure */			
-			return 0;
+			return -ECANCELED;
 		}
     memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
     res->unit = UNIT_TEMP_C;

--- a/drivers/include/apds9007.h
+++ b/drivers/include/apds9007.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2017 Hyung-Sin Kim
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_apds9007 light sensor
+ * @ingroup     drivers_sensors
+ *
+ * The connection between the MCU and the APDS9007 is based on the
+ * GPIO-interface.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Driver for the APDS9007 light sensor
+ *
+ * @author      Hyung-Sin <hs.kim@berkeley.edu>
+ */
+
+#ifndef APDS9007_H_
+#define APDS9007_H_
+
+#include <stdint.h>
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
+#ifndef APDS9007_STABILIZATION_TIME
+#define APDS9007_STABILIZATION_TIME 20000UL
+#endif
+
+/**
+ * @brief   Parameters needed for device initialization
+ */
+typedef struct {
+    gpio_t    gpio;            /**< GPIO pin that sensor is connected to */
+    adc_t     adc;             /**< ADC channel that sensor is connected to */
+    adc_res_t res;             /**< ADC resolution that sensor uses */
+} apds9007_params_t;
+
+/**
+  * @brief   Device descriptor for a APDS9007 device
+  * @{
+  */
+typedef struct {
+    apds9007_params_t p;
+} apds9007_t;
+/** @} */
+
+/**
+ * @brief   Initialize an APDS9007 device
+ *
+ * @param[out] dev          device descriptor
+ * @param[in] params        I2C bus the device is connected to
+ *
+ * The valid address range is 0x1E - 0x1F depending on the configuration of the
+ * address pins SA0 and SA1.
+ *
+ * @return                   0 on success
+ * @return                  -1 on error
+ * @return                  -2 on invalid address
+ */
+int apds9007_init(apds9007_t* dev, const apds9007_params_t* params);
+
+int apds9007_set_active(apds9007_t* dev);
+
+int apds9007_set_idle(apds9007_t* dev);
+
+int apds9007_read(apds9007_t* dev, int16_t *light);
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* APDS9007_H_ */

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -24,6 +24,7 @@
  * @author      Daniel Krebs <github@daniel-krebs.net>
  * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author      Hyung-Sin Kim <hs.kim@berkeley.edu>
  */
 
 #ifndef AT86RF2XX_H

--- a/drivers/include/ekmb1101111.h
+++ b/drivers/include/ekmb1101111.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2017 Hyung-Sin Kim
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_ekmb1101111 PIR motion sensor
+ * @ingroup     drivers_sensors
+ *
+ * The connection between the MCU and the EKMB1101111 is based on the
+ * GPIO-interface.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Driver for the EKMB1101111 PIR motions sensor
+ *
+ * @author      Hyung-Sin <hs.kim@berkeley.edu>
+ */
+
+#ifndef EKMB1101111_H_
+#define EKMB1101111_H_
+
+#include <stdint.h>
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/**
+ * @brief   Parameters needed for device initialization
+ */
+typedef struct {
+    gpio_t    gpio;            /**< GPIO pin that sensor is connected to */
+} ekmb1101111_params_t;
+
+/**
+  * @brief   Device descriptor for a EKMB1101111 device
+  * @{
+  */
+typedef struct {
+    ekmb1101111_params_t p;
+} ekmb1101111_t;
+/** @} */
+
+/**
+ * @brief   Initialize an EKMB1101111 device
+ *
+ * @param[out] dev          device descriptor
+ * @param[in] params        GPIO bus the device is connected to
+ *
+ * The valid address range is 0x1E - 0x1F depending on the configuration of the
+ * address pins SA0 and SA1.
+ *
+ * @return                   0 on success
+ * @return                  -1 on error
+ * @return                  -2 on invalid address
+ */
+int ekmb1101111_init(ekmb1101111_t* dev, const ekmb1101111_params_t* params);
+
+int ekmb1101111_read(ekmb1101111_t* dev, int16_t *light);
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* EKMB1101111_H_ */

--- a/drivers/include/fxos8700.h
+++ b/drivers/include/fxos8700.h
@@ -153,13 +153,21 @@ extern "C" {
 #define FXOS8700_REG_A_FFMT_THS_Z_LSB   (0x78)
 /** @} */
 
+
+/**
+ * @brief   Parameters needed for device initialization
+ */
+typedef struct {
+    i2c_t i2c;              /**< I2C device that sensor is connected to */
+    uint8_t addr;           /**< I2C address of this particular sensor */
+} fxos8700_params_t;
+
 /**
   * @brief   Device descriptor for a AT30TSE75x device
   * @{
   */
 typedef struct {
-    i2c_t i2c;          /**< I2C device that sensor is connected to */
-    uint8_t addr;       /**< I2C address of this particular sensor */
+    fxos8700_params_t p;
     uint8_t whoami;
 } fxos8700_t;
 
@@ -176,6 +184,25 @@ typedef struct {
     int16_t mag_z;
 } fxos8700_measurement_t;
 
+/**
+  * @brief   Individual accel measurement
+  * @{
+  */
+typedef struct {
+    int16_t acc_x;
+    int16_t acc_y;
+    int16_t acc_z;
+} fxos8700_measurement_acc_t;
+
+/**
+  * @brief   Individual mag measurement
+  * @{
+  */
+typedef struct {
+    int16_t mag_x;
+    int16_t mag_y;
+    int16_t mag_z;
+} fxos8700_measurement_mag_t;
 
 typedef union {
   struct {
@@ -240,7 +267,7 @@ typedef union {
  * @return                  -1 on error
  * @return                  -2 on invalid address
  */
-int fxos8700_init(fxos8700_t* dev, i2c_t i2c, uint8_t addr);
+int fxos8700_init(fxos8700_t* dev, const fxos8700_params_t* params); //i2c_t i2c, uint8_t addr);
 
 int fxos8700_set_active(fxos8700_t* dev);
 
@@ -248,6 +275,9 @@ int fxos8700_set_idle(fxos8700_t* dev);
 
 int fxos8700_read(fxos8700_t* dev, fxos8700_measurement_t* m);
 
+int fxos8700_read_mag(fxos8700_t* dev, fxos8700_measurement_mag_t* m);
+
+int fxos8700_read_acc(fxos8700_t* dev, fxos8700_measurement_acc_t* m);
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/hdc1000.h
+++ b/drivers/include/hdc1000.h
@@ -120,7 +120,7 @@ int hdc1000_init(hdc1000_t *dev, const hdc1000_params_t *params);
  *
  * @param[in]  dev          device descriptor of sensor
  */
-void hdc1000_trigger_conversion(hdc1000_t *dev);
+int hdc1000_trigger_conversion(hdc1000_t *dev);
 
 /**
  * @brief   Read conversion results for temperature and humidity
@@ -129,7 +129,7 @@ void hdc1000_trigger_conversion(hdc1000_t *dev);
  * @param[out] temp         temperature [in 100 * degree centigrade]
  * @param[out] hum          humidity [in 100 * percent relative]
  */
-void hdc1000_get_results(hdc1000_t *dev, int16_t *temp, int16_t *hum);
+int hdc1000_get_results(hdc1000_t *dev, int16_t *temp, int16_t *hum);
 
 /**
  * @brief   Convenience function for reading temperature and humidity
@@ -141,7 +141,7 @@ void hdc1000_get_results(hdc1000_t *dev, int16_t *temp, int16_t *hum);
  * @param[out] temp         temperature [in 100 * degree centigrade]
  * @param[out] hum          humidity [in 100 * percent relative]
  */
-void hdc1000_read(hdc1000_t *dev, int16_t *temp, int16_t *hum);
+int hdc1000_read(hdc1000_t *dev, int16_t *temp, int16_t *hum);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/push_button.h
+++ b/drivers/include/push_button.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2017 Hyung-Sin Kim
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_push_button sensor
+ * @ingroup     drivers_sensors
+ *
+ * The connection between the MCU and the PUSH_BUTTON is based on the
+ * GPIO-interface.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Driver for the PUSH_BUTTON sensor
+ *
+ * @author      Hyung-Sin <hs.kim@berkeley.edu>
+ */
+
+#ifndef PUSH_BUTTON_H_
+#define PUSH_BUTTON_H_
+
+#include <stdint.h>
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/**
+ * @brief   Parameters needed for device initialization
+ */
+typedef struct {
+    gpio_t    gpio;            /**< GPIO pin that sensor is connected to */
+} push_button_params_t;
+
+/**
+  * @brief   Device descriptor for a PUSH_BUTTON device
+  * @{
+  */
+typedef struct {
+    push_button_params_t p;
+} push_button_t;
+/** @} */
+
+/**
+ * @brief   Initialize an PUSH_BUTTON device
+ *
+ * @param[out] dev          device descriptor
+ * @param[in] params        GPIO bus the device is connected to
+ *
+ * The valid address range is 0x1E - 0x1F depending on the configuration of the
+ * address pins SA0 and SA1.
+ *
+ * @return                   0 on success
+ * @return                  -1 on error
+ * @return                  -2 on invalid address
+ */
+int push_button_init(push_button_t* dev, const push_button_params_t* params);
+
+int push_button_read(int16_t *button_events);
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* PUSH_BUTTON_ */

--- a/drivers/include/saul.h
+++ b/drivers/include/saul.h
@@ -87,6 +87,8 @@ enum {
     SAUL_SENSE_COLOR    = 0x88,     /**< sensor: (light) color */
     SAUL_SENSE_PRESS    = 0x89,     /**< sensor: pressure */
     SAUL_SENSE_ANALOG   = 0x8a,     /**< sensor: raw analog value */
+    SAUL_SENSE_AMBTEMP  = 0x8b,     /**< sensor: ambient temperature */
+    SAUL_SENSE_OCCUP    = 0x8c,     /**< sensor: occupancy */
     SAUL_CLASS_ANY      = 0xff      /**< any device - wildcard */
     /* extend this list as needed... */
 };

--- a/drivers/include/tmp006.h
+++ b/drivers/include/tmp006.h
@@ -118,6 +118,14 @@ extern "C"
 typedef struct {
     i2c_t i2c;              /**< I2C device, the sensor is connected to */
     uint8_t addr;           /**< the sensor's slave address on the I2C bus */
+    uint8_t  conv_rate;     /**< sensor's conversion rate */
+} tmp006_params_t;
+
+/**
+ * @brief Device descriptor for TMP006 sensors.
+ */
+typedef struct {
+    tmp006_params_t p;
     bool initialized;       /**< sensor status, true if sensor is initialized */
 } tmp006_t;
 
@@ -146,7 +154,7 @@ int tmp006_test(tmp006_t *dev);
  * @return                  -3 if sensor test failed
  * @return                  -4 if sensor configuration failed
  */
-int tmp006_init(tmp006_t *dev, i2c_t i2c, uint8_t address, uint8_t conv_rate);
+int tmp006_init(tmp006_t *dev, const tmp006_params_t *params); //i2c_t i2c, uint8_t address, uint8_t conv_rate);
 
 /**
  * @brief Reset the TMP006 sensor. After that, the sensor should be reinitialized.
@@ -179,7 +187,7 @@ int tmp006_set_active(tmp006_t *dev);
 int tmp006_set_standby(tmp006_t *dev);
 
 /**
- * @brief Read sensor's data.
+ * @brief Get prepared sensor's data.
  *
  * @param[in]  dev          device descriptor of sensor
  * @param[out] rawv         object voltage value
@@ -189,7 +197,18 @@ int tmp006_set_standby(tmp006_t *dev);
  * @return                  0 on success
  * @return                  -1 on error
  */
-int tmp006_read(tmp006_t *dev, int16_t *rawv, int16_t *rawt, uint8_t *drdy);
+int tmp006_get_results(tmp006_t *dev, int16_t *rawv, int16_t *rawt, uint8_t *drdy);
+
+/**
+ * @brief Read sensor's data.
+ *
+ * @param[in]  dev          device descriptor of sensor
+ * @param[out] rawt         raw die temperature
+ *
+ * @return                  0 on success
+ * @return                  -1 on error
+ */
+int tmp006_read(tmp006_t *dev, int16_t *rawt);
 
 /**
  * @brief Convert raw sensor values to temperature.

--- a/drivers/push_button/Makefile
+++ b/drivers/push_button/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/push_button/include/push_button_params.h
+++ b/drivers/push_button/include/push_button_params.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2017 Hyung-Sin Kim
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_push_button
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for PUSH_BUTTON devices
+ *
+ * @author      Hyung-Sin Kim <hs.kim@berkeley.edu>
+ */
+
+#ifndef PUSH_BUTTON_PARAMS_H
+#define PUSH_BUTTON_PARAMS_H
+
+#include "board.h"
+#include "push_button.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Set default configuration parameters for the PUSH_BUTTON driver
+ * @{
+ */
+#ifndef PUSH_BUTTON_PARAMS_BOARD
+#define PUSH_BUTTON_PARAMS_DEFAULT  { .gpio = GPIO_PIN(PA, 19) }
+#endif 
+/**@}*/
+
+/**
+ * @brief   PUSH_BUTTON configuration
+ */
+static const push_button_params_t push_button_params[] =
+{
+#ifdef PUSH_BUTTON_PARAMS_BOARD
+    PUSH_BUTTON_PARAMS_BOARD,
+#else
+    PUSH_BUTTON_PARAMS_DEFAULT,
+#endif
+};
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t push_button_saul_info[] =
+{
+    {
+        .name = "button",
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PUSH_BUTTON_PARAMS_H */
+/** @} */

--- a/drivers/push_button/push_button.c
+++ b/drivers/push_button/push_button.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2017 Hyung-Sin Kim
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     drivers_push_button
+ * @{
+ *
+ * @file
+ * @brief       Driver for the PUSH BUTTON Sensor.
+ *
+ * @author      Hyung-Sin Kim <hs.kim@berkeley.edu>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "push_button.h"
+#include "xtimer.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+int16_t  push_button_events;
+
+void push_button_trigger(void* arg) {
+		push_button_events++;
+}
+
+int push_button_init(push_button_t *dev, const push_button_params_t *params)
+{    
+		dev->p.gpio = params->gpio;
+		push_button_events = 0;
+    gpio_init_int(params->gpio, GPIO_IN_PU, GPIO_FALLING, push_button_trigger, NULL);
+		return 0;
+}
+
+int push_button_read(int16_t *button_events)
+{
+  *button_events     = push_button_events;
+	push_button_events = 0;
+  return 0;
+}
+

--- a/drivers/push_button/push_button.c
+++ b/drivers/push_button/push_button.c
@@ -37,7 +37,9 @@ int push_button_init(push_button_t *dev, const push_button_params_t *params)
 {    
 		dev->p.gpio = params->gpio;
 		push_button_events = 0;
-    gpio_init_int(params->gpio, GPIO_IN_PU, GPIO_FALLING, push_button_trigger, NULL);
+    if (gpio_init_int(params->gpio, GPIO_IN_PU, GPIO_FALLING, push_button_trigger, NULL)) {
+			return -1;
+		}
 		return 0;
 }
 

--- a/drivers/push_button/push_button_saul.c
+++ b/drivers/push_button/push_button_saul.c
@@ -25,7 +25,10 @@
 
 static int read_button(void *dev, phydat_t *res)
 {
-    push_button_read(&(res->val[0]));
+    if (push_button_read(&(res->val[0]))) {
+			/* Read failure */
+			return 0;
+		}
     memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
     res->unit  = 0;
     res->scale = 0;

--- a/drivers/push_button/push_button_saul.c
+++ b/drivers/push_button/push_button_saul.c
@@ -27,7 +27,7 @@ static int read_button(void *dev, phydat_t *res)
 {
     if (push_button_read(&(res->val[0]))) {
 			/* Read failure */
-			return 0;
+			return -ECANCELED;
 		}
     memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
     res->unit  = 0;

--- a/drivers/push_button/push_button_saul.c
+++ b/drivers/push_button/push_button_saul.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2017 Hyung-Sin Kim
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     driver_push_button
+ * @{
+ *
+ * @file
+ * @brief       PUSH_BUTTON adaption to the RIOT actuator/sensor interface
+ *
+ * @author      Hyung-Sin Kim <hs.kim@berkeley.edu>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "saul.h"
+#include "push_button.h"
+
+static int read_button(void *dev, phydat_t *res)
+{
+    push_button_read(&(res->val[0]));
+    memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
+    res->unit  = 0;
+    res->scale = 0;
+    return 1;
+}
+
+const saul_driver_t push_button_saul_driver = {
+    .read  = read_button,
+    .write = saul_notsup,
+    .type  = SAUL_SENSE_BTN,
+};

--- a/drivers/saul/saul_str.c
+++ b/drivers/saul/saul_str.c
@@ -39,6 +39,7 @@ const char *saul_class_to_str(uint8_t class_id)
         case SAUL_SENSE_ANY:    return "SENSE_ANY";
         case SAUL_SENSE_BTN:    return "SENSE_BTN";
         case SAUL_SENSE_TEMP:   return "SENSE_TEMP";
+        case SAUL_SENSE_AMBTEMP:   return "SENSE_AMBTEMP";
         case SAUL_SENSE_HUM:    return "SENSE_HUM";
         case SAUL_SENSE_LIGHT:  return "SENSE_LIGHT";
         case SAUL_SENSE_ACCEL:  return "SENSE_ACCEL";
@@ -47,6 +48,7 @@ const char *saul_class_to_str(uint8_t class_id)
         case SAUL_SENSE_COLOR:  return "SENSE_COLOR";
         case SAUL_SENSE_PRESS:  return "SENSE_PRESS";
         case SAUL_SENSE_ANALOG: return "SENSE_ANALOG";
+        case SAUL_SENSE_OCCUP:  return "SENSE_OCCUP";
         case SAUL_CLASS_ANY:    return "CLASS_ANY";
         default:                return "CLASS_UNKNOWN";
     }

--- a/drivers/tmp006/include/tmp006_params.h
+++ b/drivers/tmp006/include/tmp006_params.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2017 Hyung-Sin Kim
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_tmp006
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for TMP006 devices
+ *
+ * @author      Hyung-Sin Kim <hs.kim@berkeley.edu>
+ */
+
+#ifndef TMP006_PARAMS_H
+#define TMP006_PARAMS_H
+
+#include "board.h"
+#include "tmp006.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   default configuration parameters for the TMP006 driver
+ * @{
+ */
+#define TMP006_PARAMS_DEFAULT   { .i2c  = I2C_0, \
+                                  .addr = 0x44, \
+                                  .conv_rate  = TMP006_CONFIG_CR_AS2 }
+/**@}*/
+
+/**
+ * @brief   TMP006 configuration
+ */
+static const tmp006_params_t tmp006_params[] =
+{
+#ifdef TMP006_PARAMS_BOARD
+    TMP006_PARAMS_BOARD,
+#else
+    TMP006_PARAMS_DEFAULT,
+#endif
+};
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t tmp006_saul_info[] =
+{
+    {
+        .name = "tmp006",
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TMP006_PARAMS_H */
+/** @} */

--- a/drivers/tmp006/tmp006.c
+++ b/drivers/tmp006/tmp006.c
@@ -121,6 +121,10 @@ int tmp006_init(tmp006_t *dev, const tmp006_params_t *params)//i2c_t i2c, uint8_
         return -4;
     }
     i2c_release(dev->p.i2c);
+
+    if (tmp006_set_standby(dev)) {
+        return -5;
+    }
     dev->initialized = true;
     return 0;
 }
@@ -277,10 +281,15 @@ void tmp006_convert(int16_t rawv, int16_t rawt,  float *tamb, float *tobj)
 int tmp006_read(tmp006_t *dev, int16_t *ambtemp) 
 {
 		uint8_t drdy;
-		int error;
-		tmp006_set_active(dev);
+		if (tmp006_set_active(dev)) {
+			return -1;
+		}
 		xtimer_usleep(TMP006_CONVERSION_TIME);
-		error = tmp006_get_results(dev, NULL, ambtemp, &drdy);
-		tmp006_set_standby(dev);	
-		return error;
+		if (tmp006_get_results(dev, NULL, ambtemp, &drdy)) {
+			return -2;
+		}
+		if (tmp006_set_standby(dev)) {
+			return -3;
+		}
+		return 0;
 }

--- a/drivers/tmp006/tmp006_saul.c
+++ b/drivers/tmp006/tmp006_saul.c
@@ -28,7 +28,7 @@ static int read_ambtemp(void *dev, phydat_t *res)
     tmp006_t *d = (tmp006_t *)dev;
 		if (tmp006_read(d, &(res->val[0]))) {
 			/* Read failure */
-			res->val[0] = 0xFFFF;
+			return 0;
 		}
     memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
     res->unit = UNIT_TEMP_C;

--- a/drivers/tmp006/tmp006_saul.c
+++ b/drivers/tmp006/tmp006_saul.c
@@ -28,7 +28,7 @@ static int read_ambtemp(void *dev, phydat_t *res)
     tmp006_t *d = (tmp006_t *)dev;
 		if (tmp006_read(d, &(res->val[0]))) {
 			/* Read failure */
-			return 0;
+			return -ECANCELED;
 		}
     memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
     res->unit = UNIT_TEMP_C;

--- a/drivers/tmp006/tmp006_saul.c
+++ b/drivers/tmp006/tmp006_saul.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2017 Hyung-Sin Kim
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     driver_tmp006
+ * @{
+ *
+ * @file
+ * @brief       TMP006 adaption to the RIOT actuator/sensor interface
+ *
+ * @author      Hyung-Sin Kim <hs.kim@berkeley.edu>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "saul.h"
+#include "tmp006.h"
+
+static int read_ambtemp(void *dev, phydat_t *res)
+{
+    tmp006_t *d = (tmp006_t *)dev;
+		if (tmp006_read(d, &(res->val[0]))) {
+			/* Read failure */
+			res->val[0] = 0xFFFF;
+		}
+    memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
+    res->unit = UNIT_TEMP_C;
+    res->scale = -2;
+    return 1;
+}
+
+const saul_driver_t tmp006_saul_ambtemp_driver = {
+    .read = read_ambtemp,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_AMBTEMP,
+};

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -298,9 +298,29 @@ void auto_init(void)
     extern void auto_init_tsl2561(void);
     auto_init_tsl2561();
 #endif
+#ifdef MODULE_APDS9007
+    extern void auto_init_apds9007(void);
+    auto_init_apds9007();
+#endif
 #ifdef MODULE_HDC1000
     extern void auto_init_hdc1000(void);
     auto_init_hdc1000();
+#endif
+#ifdef MODULE_FXOS8700
+    extern void auto_init_fxos8700(void);
+    auto_init_fxos8700();
+#endif
+#ifdef MODULE_TMP006
+    extern void auto_init_tmp006(void);
+    auto_init_tmp006();
+#endif
+#ifdef MODULE_EKMB1101111
+    extern void auto_init_ekmb1101111(void);
+    auto_init_ekmb1101111();
+#endif
+#ifdef MODULE_PUSH_BUTTON
+    extern void auto_init_push_button(void);
+    auto_init_push_button();
 #endif
 #ifdef MODULE_DHT
     extern void auto_init_dht(void);

--- a/sys/auto_init/netif/auto_init_at86rf2xx.c
+++ b/sys/auto_init/netif/auto_init_at86rf2xx.c
@@ -58,7 +58,7 @@ void auto_init_at86rf2xx(void)
             LOG_ERROR("[auto_init_netif] error initializing at86rf2xx radio #%u\n", i);
         }
         else {
-#if DUTYCYCLE_EN
+#if MODULE_GNRC_DUTYMAC
              gnrc_netdev2_dutymac_init(_at86rf2xx_stacks[i],
                                     AT86RF2XX_MAC_STACKSIZE,
                                     AT86RF2XX_MAC_PRIO,

--- a/sys/auto_init/saul/auto_init_apds9007.c
+++ b/sys/auto_init/saul/auto_init_apds9007.c
@@ -56,7 +56,6 @@ void auto_init_apds9007(void)
         int res = apds9007_init(&apds9007_devs[i], &apds9007_params[i]);
         if (res != 0) {
             LOG_ERROR("[auto_init_saul] error initializing apds9007 #%u\n", i);
-						NVIC_SystemReset();
         }
         else {
             saul_entries[i].dev = &(apds9007_devs[i]);

--- a/sys/auto_init/saul/auto_init_apds9007.c
+++ b/sys/auto_init/saul/auto_init_apds9007.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2017 Hyung-Sin Kim
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/*
+ * @ingroup     auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization for APDS9007 devices
+ *
+ * @author      Hyung-Sin Kim <hs.kim@berkeley.edu>
+ *
+ * @}
+ */
+
+#ifdef MODULE_APDS9007
+
+#include "log.h"
+#include "saul_reg.h"
+#include "apds9007_params.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define APDS9007_NUM    (sizeof(apds9007_params)/sizeof(apds9007_params[0]))
+
+/**
+ * @brief   Allocate memory for the device descriptors
+ */
+static apds9007_t apds9007_devs[APDS9007_NUM];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[APDS9007_NUM];
+
+/**
+ * @brief   Reference the driver struct
+ * @{
+ */
+extern saul_driver_t apds9007_saul_light_driver;
+/** @} */
+
+
+void auto_init_apds9007(void)
+{
+    for (unsigned i = 0; i < APDS9007_NUM; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing apds9007 #%u\n", i);
+
+        int res = apds9007_init(&apds9007_devs[i], &apds9007_params[i]);
+        if (res != 0) {
+            LOG_ERROR("[auto_init_saul] error initializing apds9007 #%u\n", i);
+						NVIC_SystemReset();
+        }
+        else {
+            saul_entries[i].dev = &(apds9007_devs[i]);
+            saul_entries[i].name = apds9007_saul_info[i].name;
+            saul_entries[i].driver = &apds9007_saul_light_driver;
+            saul_reg_add(&(saul_entries[i]));
+        }
+    }
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_APDS9007 */

--- a/sys/auto_init/saul/auto_init_ekmb1101111.c
+++ b/sys/auto_init/saul/auto_init_ekmb1101111.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2017 Hyung-Sin Kim
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/*
+ * @ingroup     auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization for EKMB1101111 devices
+ *
+ * @author      Hyung-Sin Kim <hs.kim@berkeley.edu>
+ *
+ * @}
+ */
+
+#ifdef MODULE_EKMB1101111
+
+#include "log.h"
+#include "saul_reg.h"
+#include "ekmb1101111_params.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define EKMB1101111_NUM    (sizeof(ekmb1101111_params)/sizeof(ekmb1101111_params[0]))
+
+/**
+ * @brief   Allocate memory for the device descriptors
+ */
+static ekmb1101111_t ekmb1101111_devs[EKMB1101111_NUM];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[EKMB1101111_NUM];
+
+/**
+ * @brief   Reference the driver struct
+ * @{
+ */
+extern saul_driver_t ekmb1101111_saul_occup_driver;
+/** @} */
+
+
+void auto_init_ekmb1101111(void)
+{
+    for (unsigned i = 0; i < EKMB1101111_NUM; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing ekmb1101111 #%u\n", i);
+
+        int res = ekmb1101111_init(&ekmb1101111_devs[i], &ekmb1101111_params[i]);
+        if (res != 0) {
+            LOG_ERROR("[auto_init_saul] error initializing ekmb1101111 #%u\n", i);
+						NVIC_SystemReset();
+        }
+        else {
+            saul_entries[i].dev = &(ekmb1101111_devs[i]);
+            saul_entries[i].name = ekmb1101111_saul_info[i].name;
+            saul_entries[i].driver = &ekmb1101111_saul_occup_driver;
+            saul_reg_add(&(saul_entries[i]));
+        }
+    }
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_EKMB1101111 */

--- a/sys/auto_init/saul/auto_init_ekmb1101111.c
+++ b/sys/auto_init/saul/auto_init_ekmb1101111.c
@@ -56,7 +56,6 @@ void auto_init_ekmb1101111(void)
         int res = ekmb1101111_init(&ekmb1101111_devs[i], &ekmb1101111_params[i]);
         if (res != 0) {
             LOG_ERROR("[auto_init_saul] error initializing ekmb1101111 #%u\n", i);
-						NVIC_SystemReset();
         }
         else {
             saul_entries[i].dev = &(ekmb1101111_devs[i]);

--- a/sys/auto_init/saul/auto_init_fxos8700.c
+++ b/sys/auto_init/saul/auto_init_fxos8700.c
@@ -58,7 +58,6 @@ void auto_init_fxos8700(void)
         int res = fxos8700_init(&fxos8700_devs[i], &fxos8700_params[i]);
         if (res != 0) {
             LOG_ERROR("[auto_init_saul] error initializing fxos8700 #%u\n", i);
-						NVIC_SystemReset();
         }
         else {
             saul_entries[(i * 2)].dev = &(fxos8700_devs[i]);

--- a/sys/auto_init/saul/auto_init_fxos8700.c
+++ b/sys/auto_init/saul/auto_init_fxos8700.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2017 Hyung-Sin Kim
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/*
+ * @ingroup     auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization for FXOS8700 devices
+ *
+ * @author      Hyung-Sin Kim <hs.kim@berkeley.edu>
+ *
+ * @}
+ */
+
+#ifdef MODULE_FXOS8700
+
+#include "log.h"
+#include "saul_reg.h"
+
+#include "fxos8700_params.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define FXOS8700_NUM    (sizeof(fxos8700_params)/sizeof(fxos8700_params[0]))
+
+/**
+ * @brief   Allocate memory for the device descriptors
+ */
+static fxos8700_t fxos8700_devs[FXOS8700_NUM];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[FXOS8700_NUM * 2];
+
+/**
+ * @brief   Reference the driver struct
+ * @{
+ */
+extern saul_driver_t fxos8700_saul_acc_driver;
+extern saul_driver_t fxos8700_saul_mag_driver;
+/** @} */
+
+
+void auto_init_fxos8700(void)
+{
+    for (unsigned i = 0; i < FXOS8700_NUM; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing fxos8700 #%u\n", i);
+
+        int res = fxos8700_init(&fxos8700_devs[i], &fxos8700_params[i]);
+        if (res != 0) {
+            LOG_ERROR("[auto_init_saul] error initializing fxos8700 #%u\n", i);
+						NVIC_SystemReset();
+        }
+        else {
+            saul_entries[(i * 2)].dev = &(fxos8700_devs[i]);
+            saul_entries[(i * 2)].name = fxos8700_saul_info[i].name;
+            saul_entries[(i * 2)].driver = &fxos8700_saul_acc_driver;
+            saul_entries[(i * 2) + 1].dev = &(fxos8700_devs[i]);
+            saul_entries[(i * 2) + 1].name = fxos8700_saul_info[i].name;
+            saul_entries[(i * 2) + 1].driver = &fxos8700_saul_mag_driver;
+            saul_reg_add(&(saul_entries[(i * 2)]));
+            saul_reg_add(&(saul_entries[(i * 2) + 1]));
+        }
+    }
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_FXOS8700 */

--- a/sys/auto_init/saul/auto_init_hdc1000.c
+++ b/sys/auto_init/saul/auto_init_hdc1000.c
@@ -59,7 +59,6 @@ void auto_init_hdc1000(void)
         int res = hdc1000_init(&hdc1000_devs[i], &hdc1000_params[i]);
         if (res != 0) {
             LOG_ERROR("[auto_init_saul] error initializing hdc1000 #%u\n", i);
-						NVIC_SystemReset();
         }
         else {
             saul_entries[(i * 2)].dev = &(hdc1000_devs[i]);

--- a/sys/auto_init/saul/auto_init_hdc1000.c
+++ b/sys/auto_init/saul/auto_init_hdc1000.c
@@ -57,8 +57,9 @@ void auto_init_hdc1000(void)
         LOG_DEBUG("[auto_init_saul] initializing hdc1000 #%u\n", i);
 
         int res = hdc1000_init(&hdc1000_devs[i], &hdc1000_params[i]);
-        if (res < 0) {
+        if (res != 0) {
             LOG_ERROR("[auto_init_saul] error initializing hdc1000 #%u\n", i);
+						NVIC_SystemReset();
         }
         else {
             saul_entries[(i * 2)].dev = &(hdc1000_devs[i]);

--- a/sys/auto_init/saul/auto_init_push_button.c
+++ b/sys/auto_init/saul/auto_init_push_button.c
@@ -56,7 +56,6 @@ void auto_init_push_button(void)
         int res = push_button_init(&push_button_devs[i], &push_button_params[i]);
         if (res != 0) {
             LOG_ERROR("[auto_init_saul] error initializing push_button #%u\n", i);
-						NVIC_SystemReset();
         }
         else {
             saul_entries[i].dev = &(push_button_devs[i]);

--- a/sys/auto_init/saul/auto_init_push_button.c
+++ b/sys/auto_init/saul/auto_init_push_button.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2017 Hyung-Sin Kim
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/*
+ * @ingroup     auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization for PUSH_BUTTON devices
+ *
+ * @author      Hyung-Sin Kim <hs.kim@berkeley.edu>
+ *
+ * @}
+ */
+
+#ifdef MODULE_PUSH_BUTTON
+
+#include "log.h"
+#include "saul_reg.h"
+#include "push_button_params.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define PUSH_BUTTON_NUM    (sizeof(push_button_params)/sizeof(push_button_params[0]))
+
+/**
+ * @brief   Allocate memory for the device descriptors
+ */
+static push_button_t push_button_devs[PUSH_BUTTON_NUM];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[PUSH_BUTTON_NUM];
+
+/**
+ * @brief   Reference the driver struct
+ * @{
+ */
+extern saul_driver_t push_button_saul_driver;
+/** @} */
+
+
+void auto_init_push_button(void)
+{
+    for (unsigned i = 0; i < PUSH_BUTTON_NUM; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing push_button #%u\n", i);
+
+        int res = push_button_init(&push_button_devs[i], &push_button_params[i]);
+        if (res != 0) {
+            LOG_ERROR("[auto_init_saul] error initializing push_button #%u\n", i);
+						NVIC_SystemReset();
+        }
+        else {
+            saul_entries[i].dev = &(push_button_devs[i]);
+            saul_entries[i].name = push_button_saul_info[i].name;
+            saul_entries[i].driver = &push_button_saul_driver;
+            saul_reg_add(&(saul_entries[i]));
+        }
+    }
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_PUSH_BUTTON */

--- a/sys/auto_init/saul/auto_init_tmp006.c
+++ b/sys/auto_init/saul/auto_init_tmp006.c
@@ -57,7 +57,6 @@ void auto_init_tmp006(void)
         int res = tmp006_init(&tmp006_devs[i], &tmp006_params[i]);
         if (res != 0) {
             LOG_ERROR("[auto_init_saul] error initializing tmp006 #%u\n", i);
-  					NVIC_SystemReset();
         }
         else {
             saul_entries[i].dev = &(tmp006_devs[i]);

--- a/sys/auto_init/saul/auto_init_tmp006.c
+++ b/sys/auto_init/saul/auto_init_tmp006.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2017 Hyung-Sin Kim
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/*
+ * @ingroup     auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization for TMP006 devices
+ *
+ * @author      Hyung-Sin Kim <hs.kim@berkeley.edu>
+ *
+ * @}
+ */
+
+#ifdef MODULE_TMP006
+
+#include "log.h"
+#include "saul_reg.h"
+
+#include "tmp006_params.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define TMP006_NUM    (sizeof(tmp006_params)/sizeof(tmp006_params[0]))
+
+/**
+ * @brief   Allocate memory for the device descriptors
+ */
+static tmp006_t tmp006_devs[TMP006_NUM];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[TMP006_NUM];
+
+/**
+ * @brief   Reference the driver struct
+ * @{
+ */
+extern saul_driver_t tmp006_saul_ambtemp_driver;
+/** @} */
+
+
+void auto_init_tmp006(void)
+{
+    for (unsigned i = 0; i < TMP006_NUM; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing tmp006 #%u\n", i);
+
+        int res = tmp006_init(&tmp006_devs[i], &tmp006_params[i]);
+        if (res != 0) {
+            LOG_ERROR("[auto_init_saul] error initializing tmp006 #%u\n", i);
+  					NVIC_SystemReset();
+        }
+        else {
+            saul_entries[i].dev = &(tmp006_devs[i]);
+            saul_entries[i].name = tmp006_saul_info[i].name;
+            saul_entries[i].driver = &tmp006_saul_ambtemp_driver;
+            saul_reg_add(&(saul_entries[i]));
+        }
+    }
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_TMP006 */

--- a/sys/include/net/gnrc/netdev2.h
+++ b/sys/include/net/gnrc/netdev2.h
@@ -225,6 +225,10 @@ static inline void gnrc_netdev2_set_tx_feedback(gnrc_netdev2_t *dev,
 
 #if MODULE_GNRC_DUTYMAC
 
+#ifndef LEAF_NODE
+#define LEAF_NODE (1) /* 0: Always-on router, 1: Duty-cycling leaf node */
+#endif
+
 #ifndef DUTYCYCLE_SLEEP_INTERVAL
 #define DUTYCYCLE_SLEEP_INTERVAL 2000000UL /* 1) When it is ZERO, a leaf node does not send beacons
                         						(i.e., extremely low duty-cycle,

--- a/sys/include/net/gnrc/netdev2.h
+++ b/sys/include/net/gnrc/netdev2.h
@@ -223,7 +223,20 @@ static inline void gnrc_netdev2_set_tx_feedback(gnrc_netdev2_t *dev,
 }
 #endif
 
-#if DUTYCYCLE_EN
+#if MODULE_GNRC_DUTYMAC
+
+#ifndef DUTYCYCLE_SLEEP_INTERVAL
+#define DUTYCYCLE_SLEEP_INTERVAL 2000000UL /* 1) When it is ZERO, a leaf node does not send beacons
+                        						(i.e., extremely low duty-cycle,
+                                                        but downlink transmission is disabled)
+                                              2) Router and leaf node should have same sleep interval.
+             								   Router does not sleep                       												   but uses the value for downlink transmissions */
+#endif
+
+#ifndef DUTYCYCLE_WAKEUP_INTERVAL
+#define DUTYCYCLE_WAKEUP_INTERVAL  6000UL    /* Don't change it w/o particular reasons */
+#endif
+
 /**
   * @brief Initialize GNRC netdev2 handler thread for dutycycling
   *

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -250,11 +250,6 @@ typedef enum {
      */
     NETOPT_RF_TESTMODE,
 
-     /**
-      * @brief   en/disable radio duty-cycling
-      */
-    NETOPT_DUTYCYCLE,
-
     /* add more options if needed */
 
     /**

--- a/sys/include/saul_reg.h
+++ b/sys/include/saul_reg.h
@@ -133,6 +133,16 @@ int saul_reg_read(saul_reg_t *dev, phydat_t *res);
  */
 int saul_reg_write(saul_reg_t *dev, phydat_t *data);
 
+
+/**
+ * @brief   Activate the given device
+ *
+ * @param[in] dev       device to activate to
+ *
+ * @return      -ENODEV if given device is invalid
+ */
+int saul_reg_active(saul_reg_t *dev);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -71,6 +71,7 @@ typedef struct xtimer {
     struct xtimer *next;        /**< reference to next timer in timer lists */
     uint32_t target;            /**< lower 32bit absolute target time */
     uint32_t long_target;       /**< upper 32bit absolute target time */
+		bool null_callback;
     xtimer_callback_t callback;  /**< callback function to call when timer
                                      expires */
     void *arg;                  /**< argument to pass to callback function */

--- a/sys/include/xtimer/implementation.h
+++ b/sys/include/xtimer/implementation.h
@@ -60,7 +60,7 @@ static inline uint32_t _xtimer_lltimer_mask(uint32_t val)
  * @internal
  */
 uint64_t _xtimer_now64(void);
-int _xtimer_set_absolute(xtimer_t *timer, uint32_t target);
+int _xtimer_set_absolute(xtimer_t *timer, uint32_t target, uint32_t now);
 void _xtimer_set64(xtimer_t *timer, uint32_t offset, uint32_t long_offset);
 void _xtimer_set(xtimer_t *timer, uint32_t offset);
 void _xtimer_periodic_wakeup(uint32_t *last_wakeup, uint32_t period);
@@ -295,6 +295,8 @@ static inline bool xtimer_less64(xtimer_ticks64_t a, xtimer_ticks64_t b)
 {
     return (a.ticks64 < b.ticks64);
 }
+
+
 
 #endif /* !defined(DOXYGEN) */
 

--- a/sys/net/gnrc/link_layer/dutymac/gnrc_netdev2_duty_leaf.c
+++ b/sys/net/gnrc/link_layer/dutymac/gnrc_netdev2_duty_leaf.c
@@ -40,7 +40,7 @@
 
 #if LEAF_NODE
 
-#define ENABLE_DEBUG    (1)
+#define ENABLE_DEBUG    (0)
 #include "debug.h"
 
 #if defined(MODULE_OD) && ENABLE_DEBUG

--- a/sys/net/gnrc/link_layer/dutymac/gnrc_netdev2_duty_leaf.c
+++ b/sys/net/gnrc/link_layer/dutymac/gnrc_netdev2_duty_leaf.c
@@ -38,10 +38,9 @@
 
 #include "xtimer.h"
 
-#if DUTYCYCLE_EN
 #if LEAF_NODE
 
-#define ENABLE_DEBUG    (0)
+#define ENABLE_DEBUG    (1)
 #include "debug.h"
 
 #if defined(MODULE_OD) && ENABLE_DEBUG
@@ -50,6 +49,8 @@
 
 #define NETDEV2_NETAPI_MSG_QUEUE_SIZE 8
 #define NETDEV2_PKT_QUEUE_SIZE 4
+#define DUTYCYCLE_WAKEUP_INTERVAL  6000UL    /* Don't change it w/o particular reasons */
+
 
 static void _pass_on_packet(gnrc_pktsnip_t *pkt);
 
@@ -440,7 +441,7 @@ static void *_gnrc_netdev2_duty_thread(void *args)
 				if (dutycycle_state == DUTY_INIT) {
 					gnrc_pktsnip_t *pkt = msg.content.ptr;
 					gnrc_dutymac_netdev2->send(gnrc_dutymac_netdev2, pkt);	
-					DEBUG("gnrc_netdev2: SENDING IMMEDIATELY %lu\n");						
+					DEBUG("gnrc_netdev2: SENDING IMMEDIATELY\n");						
 				} else {
 					if (_xtimer_usec_from_ticks(timer.target - xtimer_now().ticks32) < 50000 || 
 						pending_num || radio_busy) {
@@ -533,5 +534,4 @@ kernel_pid_t gnrc_netdev2_dutymac_init(char *stack, int stacksize, char priority
 
     return res;
 }
-#endif
 #endif

--- a/sys/net/gnrc/link_layer/dutymac/gnrc_netdev2_duty_router.c
+++ b/sys/net/gnrc/link_layer/dutymac/gnrc_netdev2_duty_router.c
@@ -36,8 +36,8 @@
 
 #include "xtimer.h"
 
-#if DUTYCYCLE_EN
-#if ROUTER
+#if LEAF_NODE
+#else
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
@@ -512,5 +512,4 @@ kernel_pid_t gnrc_netdev2_dutymac_init(char *stack, int stacksize, char priority
 
     return res;
 }
-#endif
 #endif

--- a/sys/net/gnrc/link_layer/dutymac/gnrc_netdev2_duty_router.c
+++ b/sys/net/gnrc/link_layer/dutymac/gnrc_netdev2_duty_router.c
@@ -36,8 +36,7 @@
 
 #include "xtimer.h"
 
-#if LEAF_NODE
-#else
+#if !LEAF_NODE
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
@@ -48,8 +47,8 @@
 
 #define NETDEV2_NETAPI_MSG_QUEUE_SIZE 8
 #define NETDEV2_PKT_QUEUE_SIZE 4
-
 #define NEIGHBOR_TABLE_SIZE 10
+
 typedef struct {
 	uint16_t addr;
 	uint16_t dutycycle;
@@ -62,9 +61,8 @@ uint8_t neighbor_num = 0;
 
 static void _pass_on_packet(gnrc_pktsnip_t *pkt);
 
-/**	1) For a leaf node, 'timer' is used for wake-up scheduling
- *  2) For a router, 'timer' is used for broadcasting;
- *     a router does not discard a broadcasting packet during a sleep interval
+/** timer for broadcasting;
+ *  a router does not discard a broadcasting packet during a sleep interval
  */
 xtimer_t timer;
 bool broadcasting = 0;

--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_ieee802154.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_ieee802154.c
@@ -114,7 +114,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netdev2_t *gnrc_netdev2)
                 return NULL;
             }
             netif_hdr = _make_netif_hdr(ieee802154_hdr->data);
-#if DUTYCYCLE_EN
+#if MODULE_GNRC_DUTYMAC
 #if LEAF_NODE
 			/* Early sleep or additional wakeup */
 			if (((uint8_t*)ieee802154_hdr->data)[0] & IEEE802154_FCF_FRAME_PEND) {
@@ -208,7 +208,7 @@ static int _send(gnrc_netdev2_t *gnrc_netdev2, gnrc_pktsnip_t *pkt)
         src_len = IEEE802154_SHORT_ADDRESS_LEN;
         src = state->short_addr;
     }
-#if DUTYCYCLE_EN
+#if MODULE_GNRC_DUTYMAC
 	/* ToDo: Current version does not use a neighbor discovery protocol, which cannot support unicast.
           We can manually set a destination (router's address) here */
 #if LEAF_NODE

--- a/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_ieee802154.c
+++ b/sys/net/gnrc/link_layer/netdev2/gnrc_netdev2_ieee802154.c
@@ -21,7 +21,6 @@
 
 #include "net/gnrc/netdev2/ieee802154.h"
 #include "byteorder.h"
-#include "board.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
@@ -124,8 +123,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netdev2_t *gnrc_netdev2)
 				netopt_state_t sleepstate = NETOPT_STATE_SLEEP;
 				netdev->driver->set(netdev, NETOPT_STATE, &sleepstate, sizeof(netopt_state_t));
 			}
-#endif
-#if ROUTER
+#else
 			/* Data request command or Data */
 			if ((((uint8_t*)ieee802154_hdr->data)[0] & IEEE802154_FCF_TYPE_MASK) ==
 				IEEE802154_FCF_TYPE_MACCMD) {
@@ -216,10 +214,9 @@ static int _send(gnrc_netdev2_t *gnrc_netdev2, gnrc_pktsnip_t *pkt)
 #if LEAF_NODE
  	//int16_t ddd = 0x166d;
  	//dst = (uint8_t*)&ddd;
-#endif
-#if ROUTER
- 	int16_t ddd = 0x1e17;
- 	dst = (uint8_t*)&ddd;
+#else
+ 	//int16_t ddd = 0x1e17;
+ 	//dst = (uint8_t*)&ddd;
 #endif
 #endif
     /* fill MAC header, seq should be set by device */

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -56,6 +56,7 @@ void _xtimer_tsleep(uint32_t offset, uint32_t long_offset)
     xtimer_t timer;
     mutex_t mutex = MUTEX_INIT;
 
+		timer.null_callback = true;
     timer.callback = _callback_unlock_mutex;
     timer.arg = (void*) &mutex;
     timer.target = timer.long_target = 0;
@@ -69,6 +70,7 @@ void _xtimer_periodic_wakeup(uint32_t *last_wakeup, uint32_t period) {
     xtimer_t timer;
     mutex_t mutex = MUTEX_INIT;
 
+		timer.null_callback = true;
     timer.callback = _callback_unlock_mutex;
     timer.arg = (void*) &mutex;
 
@@ -119,11 +121,11 @@ void _xtimer_periodic_wakeup(uint32_t *last_wakeup, uint32_t period) {
              *
              * Since interrupts are normally enabled inside this function, this time may
              * be undeterministic. */
-            target = _xtimer_now() + offset;
+            target = now + offset; //_xtimer_now() + offset;
         }
         mutex_lock(&mutex);
         DEBUG("xps, abs: %" PRIu32 "\n", target);
-        _xtimer_set_absolute(&timer, target);
+        _xtimer_set_absolute(&timer, target, now);
         mutex_lock(&mutex);
     }
 out:


### PR DESCRIPTION
[Easy configuration for sensors and networks]

1. Application does not need to initialize sensors and networks
   Instead, we need to proclaim proper modules in the application "Makefile"

2. All sensor drivers are hidden behind SAUL: sensor/actuator abstraction layer

3. The corresponding application layer is in Apps/easyapp

4. Fix radio power management error