### PR TITLE
Drop all non-ACK/NACK control messages

### DIFF
--- a/dist/tools/rethos/rethos.c
+++ b/dist/tools/rethos/rethos.c
@@ -931,7 +931,6 @@ int main(int argc, char *argv[])
                                     /* Retransmit the last frame that was sent. */
                                     rethos_rexmit_data_frame(&serial);
                                 }
-                                continue;
                             } else if (serial.frametype == RETHOS_FRAME_TYPE_ACK) {
                                 if (serial.in_seqno == serial.rexmit_seqno) {
                                     /* Mark the frame to be retransmitted as having been ACKed so we don't retransmit it on timeout. */
@@ -942,8 +941,10 @@ int main(int argc, char *argv[])
                                         check_fatal_error("Could not cancel rexmit timer");
                                     }
                                 }
-                                continue;
+                            } else {
+                                printf("Got frame of type %d on control channel\n", serial.frametype);
                             }
+                            goto serial_done;
                         }
 
                         /* ACK the frame we just received. */
@@ -952,7 +953,7 @@ int main(int argc, char *argv[])
                         /* If it's a duplicate, just drop the frame. */
                         if (serial.received_data_frame && (serial.in_seqno == serial.last_rcvd_seqno)) {
                             printf("Got a duplicate frame on channel %d\n", serial.channel);
-                            continue;
+                            goto serial_done;
                         }
 
                         serial.received_data_frame = true;
@@ -994,6 +995,7 @@ int main(int argc, char *argv[])
                 exit(1);
             }
         }
+    serial_done:
 
         if (FD_ISSET(tap_fd, &readfds)) {
             ssize_t res = read(tap_fd, inbuf, sizeof(inbuf));

--- a/dist/tools/rethos/rethos.c
+++ b/dist/tools/rethos/rethos.c
@@ -962,7 +962,12 @@ int main(int argc, char *argv[])
                         stats.global.lost_frames += (serial.in_seqno - serial.last_rcvd_seqno - 1);
                         serial.last_rcvd_seqno = serial.in_seqno;
 
-                        printf("Got a frame on channel %d\n", serial.channel);
+                        if (serial.numbytes == 0) {
+                            printf("Got an empty frame on channel %d: dropping frame\n", serial.channel)
+                            goto serial_done;
+                        } else {
+                            printf("Got a frame on channel %d\n", serial.channel);
+                        }
 
                         if (serial.channel == STDIN_CHANNEL) {
                             checked_write(STDOUT_FILENO, serial.frame, serial.numbytes);


### PR DESCRIPTION
REthos should have been doing this all along, and this will fix the bug where brgw randomly gets EOF.

However it isn't the root of the problem.
* Go should not be giving you EOF. Sending empty packets is legal, and recv(2) returns 0 for such packets.
* The MCU firmware shouldn't be sending such messages over REthos in the first place. I will push another fix once I figure out why. For now, this should fix the problem.
