### PR TITLE
XTIMER improvement: Remove trivial callback and add STIMER to support slow XTIMER

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -71,8 +71,6 @@ typedef struct xtimer {
     struct xtimer *next;         /**< reference to next timer in timer lists */
     uint32_t target;             /**< lower 32bit absolute target time */
     uint32_t long_target;        /**< upper 32bit absolute target time */
-    bool trivial_callback;       /**< callback function is trivial (e.g empty)
-                                      and can be assumed to take zero time */
     xtimer_callback_t callback;  /**< callback function to call when timer
                                      expires */
     void *arg;                   /**< argument to pass to callback function */

--- a/sys/include/xtimer/implementation.h
+++ b/sys/include/xtimer/implementation.h
@@ -46,6 +46,16 @@ static inline uint32_t _xtimer_lltimer_now(void)
     return timer_read(XTIMER_DEV);
 }
 
+#ifdef STIMER_DEV
+/**
+ * @brief returns the (masked) low-level timer counter value for STIMER.
+ */
+static inline uint32_t _stimer_lltimer_now(void)
+{
+     return timer_read(STIMER_DEV);
+}
+#endif
+
 /**
  * @brief drop bits of a value that don't fit into the low-level timer.
  */
@@ -215,7 +225,6 @@ static inline void xtimer_set_wakeup64(xtimer_t *timer, uint64_t offset, kernel_
 
 static inline void xtimer_set(xtimer_t *timer, uint32_t offset)
 {
-    timer->trivial_callback = false;
     _xtimer_set(timer, _xtimer_ticks_from_usec(offset));
 }
 

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -56,7 +56,6 @@ void _xtimer_tsleep(uint32_t offset, uint32_t long_offset)
     xtimer_t timer;
     mutex_t mutex = MUTEX_INIT;
 
-    timer.trivial_callback = true;
     timer.callback = _callback_unlock_mutex;
     timer.arg = (void*) &mutex;
     timer.target = timer.long_target = 0;
@@ -70,7 +69,6 @@ void _xtimer_periodic_wakeup(uint32_t *last_wakeup, uint32_t period) {
     xtimer_t timer;
     mutex_t mutex = MUTEX_INIT;
 
-    timer.trivial_callback = true;
     timer.callback = _callback_unlock_mutex;
     timer.arg = (void*) &mutex;
 
@@ -142,7 +140,6 @@ static inline void _setup_msg(xtimer_t *timer, msg_t *msg, kernel_pid_t target_p
 {
     timer->callback = _callback_msg;
     timer->arg = (void*) msg;
-    timer->trivial_callback = false;
 
     /* use sender_pid field to get target_pid into callback function */
     msg->sender_pid = target_pid;
@@ -169,7 +166,6 @@ void _xtimer_set_wakeup(xtimer_t *timer, uint32_t offset, kernel_pid_t pid)
 {
     timer->callback = _callback_wakeup;
     timer->arg = (void*) ((intptr_t)pid);
-    timer->trivial_callback = false;
 
     _xtimer_set(timer, offset);
 }
@@ -178,7 +174,6 @@ void _xtimer_set_wakeup64(xtimer_t *timer, uint64_t offset, kernel_pid_t pid)
 {
     timer->callback = _callback_wakeup;
     timer->arg = (void*) ((intptr_t)pid);
-    timer->trivial_callback = false;
 
     _xtimer_set64(timer, offset, offset >> 32);
 }
@@ -255,7 +250,6 @@ int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t timeout)
     if (timeout != 0) {
         t.callback = _mutex_timeout;
         t.arg = (void *)((mutex_thread_t *)&mt);
-        t.trivial_callback = false;
         _xtimer_set64(&t, timeout, timeout >> 32);
     }
 

--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -46,7 +46,7 @@ static void _add_timer_to_long_list(xtimer_t **list_head, xtimer_t *timer);
 static void _shoot(xtimer_t *timer);
 static void _remove(xtimer_t *timer);
 static inline void _lltimer_set(uint32_t target);
-static uint32_t _time_left(uint32_t target, uint32_t reference);
+static uint32_t _time_left(uint32_t target, uint32_t reference, uint32_t now);
 
 static void _timer_callback(void);
 static void _periph_timer_callback(void *arg, int chan);
@@ -70,7 +70,13 @@ void xtimer_init(void)
 {
     /* initialize low-level timer */
     timer_init(XTIMER_DEV, XTIMER_HZ, _periph_timer_callback, NULL);
-
+#ifdef STIMER_DEV
+	/* initialize low-level timer for STIMER to support XTIMER operation 
+	   For this setup, XTIMER is expected to slow (e.g., 32kHz) and 
+	   STIMER must faster than XTIMER (e.g., 8MHz or 48MHz)
+	*/
+    timer_init(STIMER_DEV, STIMER_HZ, _periph_timer_callback, NULL);
+#endif
     /* register initial overflow tick */
     _lltimer_set(0xFFFFFFFF);
 }
@@ -171,6 +177,9 @@ static inline void _lltimer_set(uint32_t target)
 
 int _xtimer_set_absolute(xtimer_t *timer, uint32_t target, uint32_t now)
 {
+#ifndef STIMER_DEV
+    now = _xtimer_now();
+#endif
     int res = 0;
 
     DEBUG("timer_set_absolute(): now=%" PRIu32 " target=%" PRIu32 "\n", now, target);
@@ -286,12 +295,12 @@ void xtimer_remove(xtimer_t *timer)
     irq_restore(state);
 }
 
-static uint32_t _time_left(uint32_t target, uint32_t reference)
+static uint32_t _time_left(uint32_t target, uint32_t reference, uint32_t now)
 {
-    if (_xtimer_lltimer_mask(reference + XTIMER_ISR_BACKOFF) < reference) {
+    if (now < reference) {
         return 0;
     }
-
+   
     if (target > reference) {
         return target - reference;
     }
@@ -423,6 +432,19 @@ static void _next_period(void)
     _select_long_timers();
 }
 
+#ifdef STIMER_DEV
+/**
+ * @brief time difference of STIMER
+ */
+static uint32_t _stimer_diff(uint32_t prev, uint32_t now) {
+    if (now >= prev) {
+        return now - prev;
+    } else { 
+        return (0xFFFFFFFF-prev) + now;
+    }	
+}
+#endif
+
 /**
  * @brief main xtimer callback function
  */
@@ -431,7 +453,11 @@ static void _timer_callback(void)
     uint32_t next_target;
     uint32_t reference;
     uint32_t now;
-
+#ifdef STIMER_DEV
+    uint32_t prev_s;
+    uint32_t now_s;
+    uint32_t diff_s;
+#endif
     _in_handler = 1;
 
     DEBUG("_timer_callback() now=%" PRIu32 " (%" PRIu32 ")pleft=%" PRIu32 "\n",
@@ -463,10 +489,26 @@ static void _timer_callback(void)
     now = reference;
 
 overflow:
+#ifdef STIMER_DEV
+    prev_s = _stimer_lltimer_now();
+#endif
     /* check if next timers are close to expiring */
     while (timer_list_head &&
-           (_time_left(_xtimer_lltimer_mask(timer_list_head->target), now) < XTIMER_ISR_BACKOFF)) {
+           (_time_left(_xtimer_lltimer_mask(timer_list_head->target), reference, now) < XTIMER_ISR_BACKOFF)) {
 
+		/* make sure we don't fire too early */
+	    while (_time_left(_xtimer_lltimer_mask(timer_list_head->target), reference, now)) {
+#ifdef STIMER_DEV
+            do {
+                now_s = _stimer_lltimer_now();
+                diff_s = _stimer_diff(prev_s, now_s);
+            } while (diff_s < STIMER_HZ/XTIMER_HZ);			
+            now = now + diff_s*XTIMER_HZ/STIMER_HZ;
+            prev_s = now_s;
+#else
+            now = _xtimer_lltimer_now();
+#endif
+		}
         /* pick first timer in list */
         xtimer_t *timer = timer_list_head;
 
@@ -481,9 +523,18 @@ overflow:
         _shoot(timer);
 
         /* time update after executing callback */
-        if (!timer->trivial_callback) {
-          now = _xtimer_lltimer_now();
+#ifdef STIMER_DEV
+        now_s  = _stimer_lltimer_now();
+        diff_s = _stimer_diff(prev_s, now_s);	
+        DEBUG("_timer_callback() timer execution duration: %u\n", diff_s*XTIMER_HZ/STIMER_HZ);
+        if (diff_s >= STIMER_HZ/XTIMER_HZ) {
+            now = now + diff_s*XTIMER_HZ/STIMER_HZ;
+            prev_s = now_s;		
         }
+#else
+        /* time update after executing callback */	
+        now = _xtimer_lltimer_now();
+#endif
     }
 
     /* possibly executing all callbacks took enough
@@ -495,6 +546,7 @@ overflow:
               timer_list_head != NULL);
         _next_period();
         reference = 0;
+        now = _xtimer_lltimer_now();
         goto overflow;
     }
 
@@ -503,7 +555,8 @@ overflow:
         next_target = timer_list_head->target - XTIMER_OVERHEAD;
 
         /* make sure we're not setting a time in the past */
-        if (next_target < (_xtimer_lltimer_now() + XTIMER_ISR_BACKOFF)) {
+        if (next_target < (now + XTIMER_ISR_BACKOFF)) {
+            now = _xtimer_lltimer_now();
             goto overflow;
         }
     }
@@ -511,11 +564,18 @@ overflow:
         /* there's no timer planned for this timer period */
         /* schedule callback on next overflow */
         next_target = _xtimer_lltimer_mask(0xFFFFFFFF);
-
+#ifdef STIMER_DEV
+        now_s  = _stimer_lltimer_now();
+        diff_s = _stimer_diff(prev_s, now_s);
+        now    = now + diff_s*XTIMER_HZ/STIMER_HZ;
+#else
+        now = _xtimer_lltimer_now();
+#endif
         /* check for overflow again */
         if (now < reference) {
             _next_period();
             reference = 0;
+            now = _xtimer_lltimer_now();
             goto overflow;
         }
         else {
@@ -525,6 +585,7 @@ overflow:
                 while (_xtimer_lltimer_now() >= now);
                 _next_period();
                 reference = 0;
+                now = _xtimer_lltimer_now();
                 goto overflow;
             }
         }


### PR DESCRIPTION
Instead of trivial callback, STIMER (support timer) is used for measuring the timer period for executing a callback function.
STIMER is required to be faster than XTIMER.

If we don't define STIMER_DEV, XTIMER operates as the original version.