### PR TITLE
Check sentinel before copying LUID from factory block

### DIFF
--- a/boards/hamilton/include/board.h
+++ b/boards/hamilton/include/board.h
@@ -53,10 +53,10 @@ extern "C" {
 #define STIMER_HZ                      1000000UL
 
 #if (XTIMER_HZ < 1000000ul) && (STIMER_HZ >= 1000000ul)
-#define XTIMER_BACKOFF                 30  /* ticks: Threshold to determine spin or not 
+#define XTIMER_BACKOFF                 30  /* ticks: Threshold to determine spin or not
                                               It takes 150~200us to get the current time */
 #define XTIMER_OVERHEAD                6   /* ticks: How much earlier does a timer expires? */
-#define XTIMER_ISR_BACKOFF             20  
+#define XTIMER_ISR_BACKOFF             20
 #define XTIMER_PERIODIC_RELATIVE       100
 #endif
 

--- a/sys/luid/luid.c
+++ b/sys/luid/luid.c
@@ -52,9 +52,12 @@ void luid_base(void *buf, size_t len)
     memset(buf, LUID_BACKUP_SEED, len);
 
 #ifdef HAS_FACTORY_BLOCK
-    memcpy(buf, fb_eui64, 8);
-#else
-#if CPUID_LEN
+    if (HAS_FACTORY_BLOCK) {
+        memcpy(buf, fb_eui64, 8);
+        return;
+    }
+#endif
+#ifdef CPUID_LEN
     uint8_t *out = (uint8_t *)buf;
     uint8_t cid[CPUID_LEN];
 
@@ -62,6 +65,5 @@ void luid_base(void *buf, size_t len)
     for (size_t i = 0; i < CPUID_LEN; i++) {
         out[i % len] ^= cid[i];
     }
-#endif
 #endif
 }


### PR DESCRIPTION
This fixes the problem I mentioned to you earlier today.